### PR TITLE
add genPrivateKey function

### DIFF
--- a/functions_test.go
+++ b/functions_test.go
@@ -385,6 +385,60 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+// NOTE(bacongobbler): this test is really _slow_ because of how long it takes to compute
+// and generate a new crypto key.
+func TestGenPrivateKey(t *testing.T) {
+	// test that calling by default generates an RSA private key
+	tpl := `{{genPrivateKey ""}}`
+	out, err := runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "RSA PRIVATE KEY") {
+		t.Error("Expected RSA PRIVATE KEY")
+	}
+	// test all acceptable arguments
+	tpl = `{{genPrivateKey "rsa"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "RSA PRIVATE KEY") {
+		t.Error("Expected RSA PRIVATE KEY")
+	}
+	tpl = `{{genPrivateKey "dsa"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "DSA PRIVATE KEY") {
+		t.Error("Expected DSA PRIVATE KEY")
+	}
+	tpl = `{{genPrivateKey "ecdsa"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "EC PRIVATE KEY") {
+		t.Error("Expected EC PRIVATE KEY")
+	}
+	// test bad
+	tpl = `{{genPrivateKey "bad"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if out != "Unknown type bad" {
+		t.Error("Expected type 'bad' to be an unknown crypto algorithm")
+	}
+	// ensure that we can base64 encode the string
+	tpl = `{{genPrivateKey "rsa" | b64enc}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func runt(tpl, expect string) error {
 	return runtv(tpl, expect, map[string]string{})
 }


### PR DESCRIPTION
This function generates a new crypto key based on the crypto type. By default the type is "rsa".

Addresses use cases like ours at deis/charts#237, where [helm](http://helm.sh/) uses sprig for its templates. This is useful for us so we can generate rsa/dsa/ecdsa private keys on the fly without having to hard-code the keys in the templates.

Note that this bumps up the unit test time significantly (~11 seconds on my machine) from a few milliseconds due to the amount of time it takes to compute and generate a new crypto key each time the function is called.

if this doesn't seem fitting for sprig, I'd be more than happy to PR this against helm; I just thought these functions might be useful to someone else (or it could just be us that generates RSA keys on the fly, which is cool too). :)