### PR TITLE
feat(sprig): Add file path utility funcs from stdlib `path`.

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -187,6 +187,7 @@ import (
 	"math"
 	"math/big"
 	"os"
+	"path"
 	"reflect"
 	"strconv"
 	"strings"
@@ -372,10 +373,10 @@ var genericMap = map[string]interface{}{
 	"expandenv": func(s string) string { return os.ExpandEnv(s) },
 
 	// File Paths:
-	"base" path.Base,
-	"dir": path.Dir,
+	"base":  path.Base,
+	"dir":   path.Dir,
 	"clean": path.Clean,
-	"ext": path.Ext,
+	"ext":   path.Ext,
 	"isAbs": path.IsAbs,
 
 	// Encoding:

--- a/functions.go
+++ b/functions.go
@@ -99,6 +99,14 @@ OS:
 	- env: Resolve an environment variable
 	- expandenv: Expand a string through the environment
 
+File Paths:
+	- base: Return the last element of a path. https://golang.org/pkg/path#Base
+	- dir: Remove the last element of a path. https://golang.org/pkg/path#Dir
+	- clean: Clean a path to the shortest equivalent name.  (e.g. remove "foo/.."
+	from "foo/../bar.html") https://golang.org/pkg/path#Clean
+	- ext: https://golang.org/pkg/path#Ext
+	- isAbs: https://golang.org/pkg/path#IsAbs
+
 Encoding:
 	- b64enc: Base 64 encode a string.
 	- b64dec: Base 64 decode a string.
@@ -362,6 +370,13 @@ var genericMap = map[string]interface{}{
 	// OS:
 	"env":       func(s string) string { return os.Getenv(s) },
 	"expandenv": func(s string) string { return os.ExpandEnv(s) },
+
+	// File Paths:
+	"base" path.Base,
+	"dir": path.Dir,
+	"clean": path.Clean,
+	"ext": path.Ext,
+	"isAbs": path.IsAbs,
 
 	// Encoding:
 	"b64enc": base64encode,

--- a/functions_test.go
+++ b/functions_test.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/aokoli/goutils"
+	"github.com/stretchr/testify/assert"
 )
 
 // This is woefully incomplete. Please help.
@@ -549,6 +550,27 @@ func TestUntilStep(t *testing.T) {
 		}
 	}
 
+}
+
+func TestBase(t *testing.T) {
+	assert.NoError(t, runt(`{{ base "foo/bar" }}`, "bar"))
+}
+
+func TestDir(t *testing.T) {
+	assert.NoError(t, runt(`{{ dir "foo/bar/baz" }}`, "foo/bar"))
+}
+
+func TestIsAbs(t *testing.T) {
+	assert.NoError(t, runt(`{{ isAbs "/foo" }}`, "true"))
+	assert.NoError(t, runt(`{{ isAbs "foo" }}`, "false"))
+}
+
+func TestClean(t *testing.T) {
+	assert.NoError(t, runt(`{{ clean "/foo/../foo/../bar" }}`, "/bar"))
+}
+
+func TestExt(t *testing.T) {
+	assert.NoError(t, runt(`{{ ext "/foo/bar/baz.txt" }}`, ".txt"))
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
These template functions should make working with paths easier.