### PR TITLE
Update travis-ci tested versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+/.glide

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.3
-  - 1.4
-  - 1.5
+  - 1.6
+  - 1.7
   - tip
 
 # Setting sudo access to false will let Travis CI use containers rather than


### PR DESCRIPTION
The tests added for set/unset rely on the template space-trimming
feature added in 1.6, and it's reasonable to only support 1.6+ anyways.

Because of the 1.6-requiring changes, travis has been failing on master for a bit.

cc @technosophos since your commit was the one to introduce 1.6 features.