### PR TITLE
add merge function to dict

### DIFF
--- a/dict.go
+++ b/dict.go
@@ -1,5 +1,7 @@
 package sprig
 
+import "github.com/imdario/mergo"
+
 func set(d map[string]interface{}, key string, value interface{}) map[string]interface{} {
 	d[key] = value
 	return d
@@ -71,4 +73,12 @@ func dict(v ...interface{}) map[string]interface{} {
 		dict[key] = v[i+1]
 	}
 	return dict
+}
+
+func merge(dst map[string]interface{}, src map[string]interface{}) interface{} {
+	if err := mergo.Merge(&dst, src); err != nil {
+		// Swallow errors inside of a template.
+		return ""
+	}
+	return dst
 }

--- a/dict_test.go
+++ b/dict_test.go
@@ -135,3 +135,40 @@ func TestCompact(t *testing.T) {
 		assert.NoError(t, runt(tpl, expect))
 	}
 }
+
+func TestMerge(t *testing.T) {
+	dict := map[string]interface{}{
+		"src": map[string]interface{}{
+			"a": 1,
+			"b": 2,
+			"d": map[string]interface{}{
+				"e": "four",
+			},
+			"g": []int{6, 7},
+		},
+		"dst": map[string]interface{}{
+			"a": "one",
+			"c": 3,
+			"d": map[string]interface{}{
+				"f": 5,
+			},
+			"g": []int{8, 9},
+		},
+	}
+	tpl := `{{merge .dst .src}}`
+	_, err := runRaw(tpl, dict)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := map[string]interface{}{
+		"a": "one", // key overridden
+		"b": 2,     // merged from src
+		"c": 3,     // merged from dst
+		"d": map[string]interface{}{ // deep merge
+			"e": "four",
+			"f": 5,
+		},
+		"g": []int{8, 9}, // overridden - arrays are not merged
+	}
+	assert.Equal(t, expected, dict["dst"])
+}

--- a/functions.go
+++ b/functions.go
@@ -227,6 +227,7 @@ var genericMap = map[string]interface{}{
 	"keys":   keys,
 	"pick":   pick,
 	"omit":   omit,
+	"merge":  merge,
 
 	"append": push, "push": push,
 	"prepend": prepend,

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: d366098dbe0d3a7bc5afdc55b91fb2a75e3443ff976e1a3b87a79e22cfead454
-updated: 2017-04-07T09:31:43.889475111-06:00
+hash: 494daca29a96a422cad49dab1873de4062caf2fc3c7ba8b3dc6c153594235f94
+updated: 2017-05-02T13:31:24.9950987+01:00
 imports:
 - name: github.com/aokoli/goutils
   version: 9c37978a95bd5c709a15883b6242714ea6709e64
+- name: github.com/imdario/mergo
+  version: 3e95a51e0639b4cf372f2ccf74c86749d747fbdc
 - name: github.com/Masterminds/goutils
   version: 45307ec16e3cd47cd841506c081f7afd8237d210
 - name: github.com/Masterminds/semver
@@ -11,9 +13,19 @@ imports:
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/stretchr/testify
   version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  subpackages:
+  - assert
 - name: golang.org/x/crypto
   version: 420870623a70591d5e0b187c77c95455a1224ca6
   subpackages:
-  - scrypt
   - pbkdf2
-devImports: []
+  - scrypt
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,3 +10,5 @@ import:
 - package: github.com/Masterminds/semver
   version: v1.2.2
 - package: github.com/stretchr/testify
+- package: github.com/imdario/mergo
+  version: ~0.2.2


### PR DESCRIPTION
Adds a merge function using https://github.com/imdario/mergo.

For https://github.com/prydonius/common-chart/tree/merge-approach in Helm. I've left out MergeWithOverwrite and other functions for now as there may be compatibility issues in Helm. Want to see if we can get this working as-is with Helm, and add the other functions after. cc @technosophos 