### PR TITLE
strings: Add nindent function

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -57,6 +57,7 @@ String Functions
 	- squote: Wrap string(s) in double quotation marks, does not escape content.
 	- cat: Concatenate strings, separating them by spaces. `cat $a $b $c`.
 	- indent: Indent a string using space characters. `indent 4 "foo\nbar"` produces "    foo\n    bar"
+	- nindent: Indent a string using space characters and prepend a new line. `indent 4 "foo\nbar"` produces "\n    foo\n    bar"
 	- replace: Replace an old with a new in a string: `$name | replace " " "-"`
 	- plural: Choose singular or plural based on length: `len $fish | plural "one anchovy" "many anchovies"`
 	- sha256sum: Generate a hex encoded sha256 hash of the input

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -239,6 +239,19 @@ indent 4 $lots_of_text
 
 The above will indent every line of text by 4 space characters.
 
+## nindent
+
+The `nindent` function is the same as the indent function, but prepends a new
+line to the beginning of the string. This is useful when combined with an
+action's trim preceding white space left delimiter, `{{-`.
+
+```
+nindent 4 $lots_of_text
+```
+
+The above will indent every line of text by 4 space characters and add a new
+line to the beginning.
+
 ## replace
 
 Perform simple string replacement.

--- a/functions.go
+++ b/functions.go
@@ -137,6 +137,7 @@ var genericMap = map[string]interface{}{
 	"squote":    squote,
 	"cat":       cat,
 	"indent":    indent,
+	"nindent":   nindent,
 	"replace":   replace,
 	"plural":    plural,
 	"sha256sum": sha256sum,
@@ -263,10 +264,10 @@ var genericMap = map[string]interface{}{
 	"fail": func(msg string) (string, error) { return "", errors.New(msg) },
 
 	// Regex
-	"regexMatch": regexMatch,
-	"regexFindAll": regexFindAll,
-	"regexFind": regexFind,
-	"regexReplaceAll": regexReplaceAll,
+	"regexMatch":             regexMatch,
+	"regexFindAll":           regexFindAll,
+	"regexFind":              regexFind,
+	"regexReplaceAll":        regexReplaceAll,
 	"regexReplaceAllLiteral": regexReplaceAllLiteral,
-	"regexSplit": regexSplit,
+	"regexSplit":             regexSplit,
 }

--- a/strings.go
+++ b/strings.go
@@ -106,6 +106,10 @@ func indent(spaces int, v string) string {
 	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
 }
 
+func nindent(spaces int, v string) string {
+	return "\n" + indent(spaces, v)
+}
+
 func replace(old, new, src string) string {
 	return strings.Replace(src, old, new, -1)
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -201,6 +201,13 @@ func TestIndent(t *testing.T) {
 	}
 }
 
+func TestNindent(t *testing.T) {
+	tpl := `{{nindent 4 "a\nb\nc"}}`
+	if err := runt(tpl, "\n    a\n    b\n    c"); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestReplace(t *testing.T) {
 	tpl := `{{"I Am Henry VIII" | replace " " "-"}}`
 	if err := runt(tpl, "I-Am-Henry-VIII"); err != nil {


### PR DESCRIPTION
Convenience function for working with YAML files, among other things.

## Problem

```go
{{ $foo := "bar\nbaz" }}
key: |-
  {{- indent 2 $foo }}
```

will produce:

```yaml
key: |-  bar
  baz
```

We could unindent, and not use white space trimming (`{{` vs `{{-`), but this breaks visual consistency. Another solution may be to pipe to an additional print, but this is inconvenient.

## Solution

```go
{{ $foo := "bar\nbaz" }}
key: |-
  {{- nindent 2 $foo }}
```

will produce:

```yaml
key: |-
  bar
  baz
```