### PR TITLE
Removing line with {{ due to blocking github pages genertion

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -242,8 +242,7 @@ The above will indent every line of text by 4 space characters.
 ## nindent
 
 The `nindent` function is the same as the indent function, but prepends a new
-line to the beginning of the string. This is useful when combined with an
-action's trim preceding white space left delimiter, `{{-`.
+line to the beginning of the string.
 
 ```
 nindent 4 $lots_of_text


### PR DESCRIPTION
The line contained {{ which is a control character for liquid
templates used by github pages that generated the docs site. With
that in the page and not being closed an error about it not being
closed occured and github pages stopped updating.

Removing the sentence with the usage of that to remove the error.