### PR TITLE
add url encoding/decoding functions

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -126,6 +126,10 @@ File Paths:
 Encoding:
 	- b64enc: Base 64 encode a string.
 	- b64dec: Base 64 decode a string.
+	- b32enc: Base 32 encode a string.
+	- b32dec: Base 32 decode a string.
+	- urlEnc: URL encode a string.
+	- urlDec: URL decode a string.
 
 Reflection:
 

--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -4,3 +4,4 @@ Sprig has the following encoding and decoding functions:
 
 - `b64enc`/`b64dec`: Encode or decode with Base64
 - `b32enc`/`b32dec`: Encode or decode with Base32
+- `urlEnc`/`urlDec`: URL encoding or decoding

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ The Sprig library provides over 70 template functions for Go's template language
   - [Integer Slice Functions](integer_slice.md): `until`, `untilStep`
 - [Date Functions](date.md): `now`, `date`, etc.
 - [Defaults Functions](defaults.md): `default`, `empty`, `coalesce`
-- [Encoding Functions](encoding.md): `b64enc`, `b64dec`, etc.
+- [Encoding Functions](encoding.md): `b64enc`, `b64dec`, `b32enc`, `b32dec`, `urlEnc`, `urlDec`, etc.
 - [Lists and List Functions](lists.md): `list`, `first`, `uniq`, etc.
 - [Dictionaries and Dict Functions](dicts.md): `dict`, `hasKey`, `pluck`, etc.
 - [Type Conversion Functions](conversion.md): `atoi`, `int64`, `toString`, etc.

--- a/encoding.go
+++ b/encoding.go
@@ -1,0 +1,39 @@
+package sprig
+
+import (
+	"encoding/base32"
+	"encoding/base64"
+	"net/url"
+)
+
+func base64encode(v string) string {
+	return base64.StdEncoding.EncodeToString([]byte(v))
+}
+
+func base64decode(v string) string {
+	data, err := base64.StdEncoding.DecodeString(v)
+	if err != nil {
+		return err.Error()
+	}
+	return string(data)
+}
+
+func base32encode(v string) string {
+	return base32.StdEncoding.EncodeToString([]byte(v))
+}
+
+func base32decode(v string) string {
+	data, err := base32.StdEncoding.DecodeString(v)
+	if err != nil {
+		return err.Error()
+	}
+	return string(data)
+}
+
+func urlEncode(v string) string {
+	return url.QueryEscape(v)
+}
+
+func urlDecode(v string) (string, error) {
+	return url.QueryUnescape(v)
+}

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,0 +1,59 @@
+package sprig
+
+import (
+	"encoding/base32"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"testing"
+)
+
+func TestBase64EncodeDecode(t *testing.T) {
+	magicWord := "coffee"
+	expect := base64.StdEncoding.EncodeToString([]byte(magicWord))
+
+	if expect == magicWord {
+		t.Fatal("Encoder doesn't work.")
+	}
+
+	tpl := `{{b64enc "coffee"}}`
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+	tpl = fmt.Sprintf("{{b64dec %q}}", expect)
+	if err := runt(tpl, magicWord); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestBase32EncodeDecode(t *testing.T) {
+	magicWord := "coffee"
+	expect := base32.StdEncoding.EncodeToString([]byte(magicWord))
+
+	if expect == magicWord {
+		t.Fatal("Encoder doesn't work.")
+	}
+
+	tpl := `{{b32enc "coffee"}}`
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+	tpl = fmt.Sprintf("{{b32dec %q}}", expect)
+	if err := runt(tpl, magicWord); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestURLEncodeDecode(t *testing.T) {
+	magicWord := "cof&+/?fee"
+	expect := url.QueryEscape(magicWord)
+
+	tpl := fmt.Sprintf(`{{urlEnc "%s"}}`, magicWord)
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+	tpl = fmt.Sprintf("{{urlDec %q}}", expect)
+	if err := runt(tpl, magicWord); err != nil {
+		t.Error(err)
+	}
+}

--- a/functions.go
+++ b/functions.go
@@ -226,6 +226,8 @@ var genericMap = map[string]interface{}{
 	"b64dec": base64decode,
 	"b32enc": base32encode,
 	"b32dec": base32decode,
+	"urlEnc": urlEncode,
+	"urlDec": urlDecode,
 
 	// Data Structures:
 	"tuple":  list, // FIXME: with the addition of append/prepend these are no longer immutable.

--- a/strings.go
+++ b/strings.go
@@ -1,8 +1,6 @@
 package sprig
 
 import (
-	"encoding/base32"
-	"encoding/base64"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -10,30 +8,6 @@ import (
 
 	util "github.com/aokoli/goutils"
 )
-
-func base64encode(v string) string {
-	return base64.StdEncoding.EncodeToString([]byte(v))
-}
-
-func base64decode(v string) string {
-	data, err := base64.StdEncoding.DecodeString(v)
-	if err != nil {
-		return err.Error()
-	}
-	return string(data)
-}
-
-func base32encode(v string) string {
-	return base32.StdEncoding.EncodeToString([]byte(v))
-}
-
-func base32decode(v string) string {
-	data, err := base32.StdEncoding.DecodeString(v)
-	if err != nil {
-		return err.Error()
-	}
-	return string(data)
-}
 
 func abbrev(width int, s string) string {
 	if width < 4 {

--- a/strings_test.go
+++ b/strings_test.go
@@ -1,9 +1,6 @@
 package sprig
 
 import (
-	"encoding/base32"
-	"encoding/base64"
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -111,40 +108,6 @@ func TestSortAlpha(t *testing.T) {
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
-	}
-}
-func TestBase64EncodeDecode(t *testing.T) {
-	magicWord := "coffee"
-	expect := base64.StdEncoding.EncodeToString([]byte(magicWord))
-
-	if expect == magicWord {
-		t.Fatal("Encoder doesn't work.")
-	}
-
-	tpl := `{{b64enc "coffee"}}`
-	if err := runt(tpl, expect); err != nil {
-		t.Error(err)
-	}
-	tpl = fmt.Sprintf("{{b64dec %q}}", expect)
-	if err := runt(tpl, magicWord); err != nil {
-		t.Error(err)
-	}
-}
-func TestBase32EncodeDecode(t *testing.T) {
-	magicWord := "coffee"
-	expect := base32.StdEncoding.EncodeToString([]byte(magicWord))
-
-	if expect == magicWord {
-		t.Fatal("Encoder doesn't work.")
-	}
-
-	tpl := `{{b32enc "coffee"}}`
-	if err := runt(tpl, expect); err != nil {
-		t.Error(err)
-	}
-	tpl = fmt.Sprintf("{{b32dec %q}}", expect)
-	if err := runt(tpl, magicWord); err != nil {
-		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
Also, this grows the number of encoding/decoding functions to a point where I felt it was useful to split those functions out of `strings.go` into a new file `encoding.go`-- same for the corresponding tests.