### PR TITLE
Update the list functions to handle int, string, and other slices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
 
 go:
-  - 1.6
-  - 1.7
-  - 1.8
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
   - tip
 
 # Setting sudo access to false will let Travis CI use containers rather than

--- a/dict_test.go
+++ b/dict_test.go
@@ -125,17 +125,6 @@ func TestSet(t *testing.T) {
 	}
 }
 
-func TestCompact(t *testing.T) {
-	tests := map[string]string{
-		`{{ list 1 0 "" "hello" | compact }}`: `[1 hello]`,
-		`{{ list "" "" | compact }}`:          `[]`,
-		`{{ list | compact }}`:                `[]`,
-	}
-	for tpl, expect := range tests {
-		assert.NoError(t, runt(tpl, expect))
-	}
-}
-
 func TestMerge(t *testing.T) {
 	dict := map[string]interface{}{
 		"src2": map[string]interface{}{

--- a/functions.go
+++ b/functions.go
@@ -249,7 +249,7 @@ var genericMap = map[string]interface{}{
 	"reverse": reverse,
 	"uniq":    uniq,
 	"without": without,
-	"has":     func(needle interface{}, haystack []interface{}) bool { return inList(haystack, needle) },
+	"has":     has,
 
 	// Crypto:
 	"genPrivateKey":     generatePrivateKey,

--- a/list.go
+++ b/list.go
@@ -1,50 +1,135 @@
 package sprig
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 )
+
+// Reflection is used in these functions so that slices and arrays of strings,
+// ints, and other types not implementing []interface{} can be worked with.
+// For example, this is useful if you need to work on the output of regexs.
 
 func list(v ...interface{}) []interface{} {
 	return v
 }
 
-func push(list []interface{}, v interface{}) []interface{} {
-	return append(list, v)
-}
+func push(list interface{}, v interface{}) []interface{} {
+	tp := reflect.TypeOf(list).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(list)
 
-func prepend(list []interface{}, v interface{}) []interface{} {
-	return append([]interface{}{v}, list...)
-}
+		l := l2.Len()
+		nl := make([]interface{}, l)
+		for i := 0; i < l; i++ {
+			nl[i] = l2.Index(i).Interface()
+		}
 
-func last(list []interface{}) interface{} {
-	l := len(list)
-	if l == 0 {
-		return nil
+		return append(nl, v)
+
+	default:
+		panic(fmt.Sprintf("Cannot push on type %s", tp))
 	}
-	return list[l-1]
 }
 
-func first(list []interface{}) interface{} {
-	if len(list) == 0 {
-		return nil
+func prepend(list interface{}, v interface{}) []interface{} {
+	//return append([]interface{}{v}, list...)
+
+	tp := reflect.TypeOf(list).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(list)
+
+		l := l2.Len()
+		nl := make([]interface{}, l)
+		for i := 0; i < l; i++ {
+			nl[i] = l2.Index(i).Interface()
+		}
+
+		return append([]interface{}{v}, nl...)
+
+	default:
+		panic(fmt.Sprintf("Cannot prepend on type %s", tp))
 	}
-	return list[0]
 }
 
-func rest(list []interface{}) []interface{} {
-	if len(list) == 0 {
-		return list
+func last(list interface{}) interface{} {
+	tp := reflect.TypeOf(list).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(list)
+
+		l := l2.Len()
+		if l == 0 {
+			return nil
+		}
+
+		return l2.Index(l - 1).Interface()
+	default:
+		panic(fmt.Sprintf("Cannot find last on type %s", tp))
 	}
-	return list[1:]
 }
 
-func initial(list []interface{}) []interface{} {
-	l := len(list)
-	if l == 0 {
-		return list
+func first(list interface{}) interface{} {
+	tp := reflect.TypeOf(list).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(list)
+
+		l := l2.Len()
+		if l == 0 {
+			return nil
+		}
+
+		return l2.Index(0).Interface()
+	default:
+		panic(fmt.Sprintf("Cannot find first on type %s", tp))
 	}
-	return list[:l-1]
+}
+
+func rest(list interface{}) []interface{} {
+	tp := reflect.TypeOf(list).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(list)
+
+		l := l2.Len()
+		if l == 0 {
+			return nil
+		}
+
+		nl := make([]interface{}, l-1)
+		for i := 1; i < l; i++ {
+			nl[i-1] = l2.Index(i).Interface()
+		}
+
+		return nl
+	default:
+		panic(fmt.Sprintf("Cannot find rest on type %s", tp))
+	}
+}
+
+func initial(list interface{}) []interface{} {
+	tp := reflect.TypeOf(list).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(list)
+
+		l := l2.Len()
+		if l == 0 {
+			return nil
+		}
+
+		nl := make([]interface{}, l-1)
+		for i := 0; i < l-1; i++ {
+			nl[i] = l2.Index(i).Interface()
+		}
+
+		return nl
+	default:
+		panic(fmt.Sprintf("Cannot find initial on type %s", tp))
+	}
 }
 
 func sortAlpha(list interface{}) []string {
@@ -59,34 +144,67 @@ func sortAlpha(list interface{}) []string {
 	return []string{strval(list)}
 }
 
-func reverse(v []interface{}) []interface{} {
-	// We do not sort in place because the incomming array should not be altered.
-	l := len(v)
-	c := make([]interface{}, l)
-	for i := 0; i < l; i++ {
-		c[l-i-1] = v[i]
+func reverse(v interface{}) []interface{} {
+	tp := reflect.TypeOf(v).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(v)
+
+		l := l2.Len()
+		// We do not sort in place because the incoming array should not be altered.
+		nl := make([]interface{}, l)
+		for i := 0; i < l; i++ {
+			nl[l-i-1] = l2.Index(i).Interface()
+		}
+
+		return nl
+	default:
+		panic(fmt.Sprintf("Cannot find reverse on type %s", tp))
 	}
-	return c
 }
 
-func compact(list []interface{}) []interface{} {
-	res := []interface{}{}
-	for _, item := range list {
-		if !empty(item) {
-			res = append(res, item)
+func compact(list interface{}) []interface{} {
+	tp := reflect.TypeOf(list).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(list)
+
+		l := l2.Len()
+		nl := []interface{}{}
+		var item interface{}
+		for i := 0; i < l; i++ {
+			item = l2.Index(i).Interface()
+			if !empty(item) {
+				nl = append(nl, item)
+			}
 		}
+
+		return nl
+	default:
+		panic(fmt.Sprintf("Cannot compact on type %s", tp))
 	}
-	return res
 }
 
-func uniq(list []interface{}) []interface{} {
-	dest := []interface{}{}
-	for _, item := range list {
-		if !inList(dest, item) {
-			dest = append(dest, item)
+func uniq(list interface{}) []interface{} {
+	tp := reflect.TypeOf(list).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(list)
+
+		l := l2.Len()
+		dest := []interface{}{}
+		var item interface{}
+		for i := 0; i < l; i++ {
+			item = l2.Index(i).Interface()
+			if !inList(dest, item) {
+				dest = append(dest, item)
+			}
 		}
+
+		return dest
+	default:
+		panic(fmt.Sprintf("Cannot find uniq on type %s", tp))
 	}
-	return dest
 }
 
 func inList(haystack []interface{}, needle interface{}) bool {
@@ -98,12 +216,44 @@ func inList(haystack []interface{}, needle interface{}) bool {
 	return false
 }
 
-func without(list []interface{}, omit ...interface{}) []interface{} {
-	res := []interface{}{}
-	for _, i := range list {
-		if !inList(omit, i) {
-			res = append(res, i)
+func without(list interface{}, omit ...interface{}) []interface{} {
+	tp := reflect.TypeOf(list).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(list)
+
+		l := l2.Len()
+		res := []interface{}{}
+		var item interface{}
+		for i := 0; i < l; i++ {
+			item = l2.Index(i).Interface()
+			if !inList(omit, item) {
+				res = append(res, item)
+			}
 		}
+
+		return res
+	default:
+		panic(fmt.Sprintf("Cannot find without on type %s", tp))
 	}
-	return res
+}
+
+func has(needle interface{}, haystack interface{}) bool {
+	tp := reflect.TypeOf(haystack).Kind()
+	switch tp {
+	case reflect.Slice, reflect.Array:
+		l2 := reflect.ValueOf(haystack)
+		var item interface{}
+		l := l2.Len()
+		for i := 0; i < l; i++ {
+			item = l2.Index(i).Interface()
+			if reflect.DeepEqual(needle, item) {
+				return true
+			}
+		}
+
+		return false
+	default:
+		panic(fmt.Sprintf("Cannot find has on type %s", tp))
+	}
 }

--- a/list_test.go
+++ b/list_test.go
@@ -23,8 +23,9 @@ func TestList(t *testing.T) {
 func TestPush(t *testing.T) {
 	// Named `append` in the function map
 	tests := map[string]string{
-		`{{ $t := tuple 1 2 3  }}{{ append $t 4 | len }}`:        "4",
-		`{{ $t := tuple 1 2 3 4  }}{{ append $t 5 | join "-" }}`: "1-2-3-4-5",
+		`{{ $t := tuple 1 2 3  }}{{ append $t 4 | len }}`:                             "4",
+		`{{ $t := tuple 1 2 3 4  }}{{ append $t 5 | join "-" }}`:                      "1-2-3-4-5",
+		`{{ $t := regexSplit "/" "foo/bar/baz" -1 }}{{ append $t "qux" | join "-" }}`: "foo-bar-baz-qux",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
@@ -32,8 +33,9 @@ func TestPush(t *testing.T) {
 }
 func TestPrepend(t *testing.T) {
 	tests := map[string]string{
-		`{{ $t := tuple 1 2 3  }}{{ prepend $t 0 | len }}`:        "4",
-		`{{ $t := tuple 1 2 3 4  }}{{ prepend $t 0 | join "-" }}`: "0-1-2-3-4",
+		`{{ $t := tuple 1 2 3  }}{{ prepend $t 0 | len }}`:                             "4",
+		`{{ $t := tuple 1 2 3 4  }}{{ prepend $t 0 | join "-" }}`:                      "0-1-2-3-4",
+		`{{ $t := regexSplit "/" "foo/bar/baz" -1 }}{{ prepend $t "qux" | join "-" }}`: "qux-foo-bar-baz",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
@@ -42,8 +44,9 @@ func TestPrepend(t *testing.T) {
 
 func TestFirst(t *testing.T) {
 	tests := map[string]string{
-		`{{ list 1 2 3 | first }}`: "1",
-		`{{ list | first }}`:       "<no value>",
+		`{{ list 1 2 3 | first }}`:                          "1",
+		`{{ list | first }}`:                                "<no value>",
+		`{{ regexSplit "/src/" "foo/src/bar" -1 | first }}`: "foo",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
@@ -51,8 +54,9 @@ func TestFirst(t *testing.T) {
 }
 func TestLast(t *testing.T) {
 	tests := map[string]string{
-		`{{ list 1 2 3 | last }}`: "3",
-		`{{ list | last }}`:       "<no value>",
+		`{{ list 1 2 3 | last }}`:                          "3",
+		`{{ list | last }}`:                                "<no value>",
+		`{{ regexSplit "/src/" "foo/src/bar" -1 | last }}`: "bar",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
@@ -61,10 +65,11 @@ func TestLast(t *testing.T) {
 
 func TestInitial(t *testing.T) {
 	tests := map[string]string{
-		`{{ list 1 2 3 | initial | len }}`:   "2",
-		`{{ list 1 2 3 | initial | last }}`:  "2",
-		`{{ list 1 2 3 | initial | first }}`: "1",
-		`{{ list | initial }}`:               "[]",
+		`{{ list 1 2 3 | initial | len }}`:                "2",
+		`{{ list 1 2 3 | initial | last }}`:               "2",
+		`{{ list 1 2 3 | initial | first }}`:              "1",
+		`{{ list | initial }}`:                            "[]",
+		`{{ regexSplit "/" "foo/bar/baz" -1 | initial }}`: "[foo bar]",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
@@ -73,10 +78,11 @@ func TestInitial(t *testing.T) {
 
 func TestRest(t *testing.T) {
 	tests := map[string]string{
-		`{{ list 1 2 3 | rest | len }}`:   "2",
-		`{{ list 1 2 3 | rest | last }}`:  "3",
-		`{{ list 1 2 3 | rest | first }}`: "2",
-		`{{ list | rest }}`:               "[]",
+		`{{ list 1 2 3 | rest | len }}`:                "2",
+		`{{ list 1 2 3 | rest | last }}`:               "3",
+		`{{ list 1 2 3 | rest | first }}`:              "2",
+		`{{ list | rest }}`:                            "[]",
+		`{{ regexSplit "/" "foo/bar/baz" -1 | rest }}`: "[bar baz]",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
@@ -85,12 +91,25 @@ func TestRest(t *testing.T) {
 
 func TestReverse(t *testing.T) {
 	tests := map[string]string{
-		`{{ list 1 2 3 | reverse | first }}`:        "3",
-		`{{ list 1 2 3 | reverse | rest | first }}`: "2",
-		`{{ list 1 2 3 | reverse | last }}`:         "1",
-		`{{ list 1 2 3 4 | reverse }}`:              "[4 3 2 1]",
-		`{{ list 1 | reverse }}`:                    "[1]",
-		`{{ list | reverse }}`:                      "[]",
+		`{{ list 1 2 3 | reverse | first }}`:              "3",
+		`{{ list 1 2 3 | reverse | rest | first }}`:       "2",
+		`{{ list 1 2 3 | reverse | last }}`:               "1",
+		`{{ list 1 2 3 4 | reverse }}`:                    "[4 3 2 1]",
+		`{{ list 1 | reverse }}`:                          "[1]",
+		`{{ list | reverse }}`:                            "[]",
+		`{{ regexSplit "/" "foo/bar/baz" -1 | reverse }}`: "[baz bar foo]",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+
+func TestCompact(t *testing.T) {
+	tests := map[string]string{
+		`{{ list 1 0 "" "hello" | compact }}`:          `[1 hello]`,
+		`{{ list "" "" | compact }}`:                   `[]`,
+		`{{ list | compact }}`:                         `[]`,
+		`{{ regexSplit "/" "foo//bar" -1 | compact }}`: "[foo bar]",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
@@ -99,11 +118,12 @@ func TestReverse(t *testing.T) {
 
 func TestUniq(t *testing.T) {
 	tests := map[string]string{
-		`{{ list 1 2 3 4 | uniq }}`:                   `[1 2 3 4]`,
-		`{{ list "a" "b" "c" "d" | uniq }}`:           `[a b c d]`,
-		`{{ list 1 1 1 1 2 2 2 2 | uniq }}`:           `[1 2]`,
-		`{{ list "foo" 1 1 1 1 "foo" "foo" | uniq }}`: `[foo 1]`,
-		`{{ list | uniq }}`:                           `[]`,
+		`{{ list 1 2 3 4 | uniq }}`:                    `[1 2 3 4]`,
+		`{{ list "a" "b" "c" "d" | uniq }}`:            `[a b c d]`,
+		`{{ list 1 1 1 1 2 2 2 2 | uniq }}`:            `[1 2]`,
+		`{{ list "foo" 1 1 1 1 "foo" "foo" | uniq }}`:  `[foo 1]`,
+		`{{ list | uniq }}`:                            `[]`,
+		`{{ regexSplit "/" "foo/foo/bar" -1 | uniq }}`: "[foo bar]",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
@@ -112,12 +132,13 @@ func TestUniq(t *testing.T) {
 
 func TestWithout(t *testing.T) {
 	tests := map[string]string{
-		`{{ without (list 1 2 3 4) 1 }}`:           `[2 3 4]`,
-		`{{ without (list "a" "b" "c" "d") "a" }}`: `[b c d]`,
-		`{{ without (list 1 1 1 1 2) 1 }}`:         `[2]`,
-		`{{ without (list) 1 }}`:                   `[]`,
-		`{{ without (list 1 2 3) }}`:               `[1 2 3]`,
-		`{{ without list }}`:                       `[]`,
+		`{{ without (list 1 2 3 4) 1 }}`:                         `[2 3 4]`,
+		`{{ without (list "a" "b" "c" "d") "a" }}`:               `[b c d]`,
+		`{{ without (list 1 1 1 1 2) 1 }}`:                       `[2]`,
+		`{{ without (list) 1 }}`:                                 `[]`,
+		`{{ without (list 1 2 3) }}`:                             `[1 2 3]`,
+		`{{ without list }}`:                                     `[]`,
+		`{{ without (regexSplit "/" "foo/bar/baz" -1 ) "foo" }}`: "[bar baz]",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
@@ -126,8 +147,9 @@ func TestWithout(t *testing.T) {
 
 func TestHas(t *testing.T) {
 	tests := map[string]string{
-		`{{ list 1 2 3 | has 1 }}`: `true`,
-		`{{ list 1 2 3 | has 4 }}`: `false`,
+		`{{ list 1 2 3 | has 1 }}`:                          `true`,
+		`{{ list 1 2 3 | has 4 }}`:                          `false`,
+		`{{ regexSplit "/" "foo/bar/baz" -1 | has "bar" }}`: `true`,
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))

--- a/strings_test.go
+++ b/strings_test.go
@@ -161,7 +161,7 @@ func TestGoutils(t *testing.T) {
 	for k, v := range tests {
 		t.Log(k)
 		if err := runt(k, v); err != nil {
-			t.Errorf("Error on tpl %s: %s", err)
+			t.Errorf("Error on tpl %q: %s", k, err)
 		}
 	}
 }
@@ -173,16 +173,16 @@ func TestRandom(t *testing.T) {
 	// Because we're using a random number generator, we need these to go in
 	// a predictable sequence:
 	if err := runt(`{{randAlphaNum 5}}`, "9bzRv"); err != nil {
-		t.Errorf("Error on tpl %s: %s", err)
+		t.Errorf("Error on tpl: %s", err)
 	}
 	if err := runt(`{{randAlpha 5}}`, "VjwGe"); err != nil {
-		t.Errorf("Error on tpl %s: %s", err)
+		t.Errorf("Error on tpl: %s", err)
 	}
 	if err := runt(`{{randAscii 5}}`, "1KA5p"); err != nil {
-		t.Errorf("Error on tpl %s: %s", err)
+		t.Errorf("Error on tpl: %s", err)
 	}
 	if err := runt(`{{randNumeric 5}}`, "26018"); err != nil {
-		t.Errorf("Error on tpl %s: %s", err)
+		t.Errorf("Error on tpl: %s", err)
 	}
 
 }


### PR DESCRIPTION
The list functions used to only handle reveiving []interface{}. The
output of regex and some other functions provided []string which is
not compatible. This approach enables list to handle other types
of slices and convert them for a unified output.

Closes #63
Closes #59 

/cc @technosophos 