### PR TITLE
dict: allow keys function to take multiple dicts

### DIFF
--- a/dict.go
+++ b/dict.go
@@ -27,10 +27,12 @@ func pluck(key string, d ...map[string]interface{}) []interface{} {
 	return res
 }
 
-func keys(dict map[string]interface{}) []string {
+func keys(dicts ...map[string]interface{}) []string {
 	k := []string{}
-	for key := range dict {
-		k = append(k, key)
+	for _, dict := range dicts {
+		for key := range dict {
+			k = append(k, key)
+		}
 	}
 	return k
 }

--- a/dict_test.go
+++ b/dict_test.go
@@ -73,6 +73,7 @@ func TestKeys(t *testing.T) {
 	tests := map[string]string{
 		`{{ dict "foo" 1 "bar" 2 | keys | sortAlpha }}`: "[bar foo]",
 		`{{ dict | keys }}`:                             "[]",
+		`{{ keys (dict "foo" 1) (dict "bar" 2) (dict "bar" 3) | uniq | sortAlpha }}`: "[bar foo]",
 	}
 	for tpl, expect := range tests {
 		if err := runt(tpl, expect); err != nil {

--- a/doc.go
+++ b/doc.go
@@ -189,7 +189,7 @@ These are used to manipulate dicts.
 	- hasKey: Takes a dict and a key, and returns boolean true if the key is in
 	  the dict.
 	- pluck: Given a key and one or more maps, get all of the values for that key.
-	- keys: Get an array of all of the keys in a dict.
+	- keys: Get an array of all of the keys in one or more dicts.
 	- pick: Select just the given keys out of the dict, and return a new dict.
 	- omit: Return a dict without the given keys.
 

--- a/docs/dicts.md
+++ b/docs/dicts.md
@@ -87,12 +87,19 @@ This is a deep merge operation.
 
 ## keys
 
-The `keys` function will return a `list` of all of the keys in a `dict`. Since
-a dictionary is _unordered_, the keys will not be in a predictable order. They
-can be sorted with `sortAlpha`.
+The `keys` function will return a `list` of all of the keys in one or more `dict`
+types. Since a dictionary is _unordered_, the keys will not be in a predictable order.
+They can be sorted with `sortAlpha`.
 
 ```
 keys $myDict | sortAlpha
+```
+
+When supplying multiple dictionaries, the keys will be concatenated. Use the `uniq`
+function along with `sortAlpha` to get a unqiue, sorted list of keys.
+
+```
+keys $myDict $myOtherDict | uniq | sortAlpha
 ```
 
 ## pick


### PR DESCRIPTION
Get keys from multiple dicts--original functionality is preserved. Need this for Helm in configmaps and secrets.