### PR TITLE
Allow customizing Root CA that used by genSignedCert

### DIFF
--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -36,6 +36,20 @@ It takes one of the values for its first param:
 - `dsa`: Generate a DSA key (L2048N256)
 - `rsa`: Generate an RSA 4096 key
 
+## buildCustomCert
+
+The `buildCustomCert` function allows customizing the certificate.
+
+It takes the following string parameters:
+
+- A base64 encoded PEM format certificate
+- A base64 encoded PEM format private key
+
+It returns a certificate object with the following attributes:
+
+- `Cert`: A PEM-encoded certificate
+- `Key`: A PEM-encoded private key
+
 ## genCA
 
 The `genCA` function generates a new, self-signed x509 certificate authority.

--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -50,6 +50,15 @@ It returns a certificate object with the following attributes:
 - `Cert`: A PEM-encoded certificate
 - `Key`: A PEM-encoded private key
 
+Example:
+
+```
+$ca := buildCustomCert "base64-encoded-ca-key" "base64-encoded-ca-crt"
+```
+
+Note that the returned object can be passed to the `genSignedCert` function
+to sign a certificate using this CA.
+
 ## genCA
 
 The `genCA` function generates a new, self-signed x509 certificate authority.

--- a/functions.go
+++ b/functions.go
@@ -255,6 +255,7 @@ var genericMap = map[string]interface{}{
 	// Crypto:
 	"genPrivateKey":     generatePrivateKey,
 	"derivePassword":    derivePassword,
+	"buildCustomCert":   buildCustomCertificate,
 	"genCA":             generateCertificateAuthority,
 	"genSelfSignedCert": generateSelfSignedCertificate,
 	"genSignedCert":     generateSignedCertificate,


### PR DESCRIPTION
Some charts may want to use a custom Root CA to generate signed certificates, this patch implements this requirement.

* In values.yaml

    ```
    root_key: base64-encoded-key

    root_ca: base64-encoded-crt
    ```
  
* In templates

    ```
    {{- $ca := buildCustomCert .Values.root_key .Values.root_ca }}
    {{- $name := default .Chart.Name .Values.nameOverride -}}
    {{- $cn := printf "%s-%s" $name .Release.Name | trunc 63 -}}
    {{- $altName1 := printf "%s.%s" $cn .Release.Namespace }}
    {{- $altName2 := printf "%s.%s.svc" $cn .Release.Namespace }}
    {{- $cert := genSignedCert $cn nil (list $altName1 $altName2) 3650 $ca }}
    ```