### PR TITLE
Generate Serial Number for TLS certs

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -369,8 +369,13 @@ func getBaseCertTemplate(
 	if err != nil {
 		return nil, err
 	}
+	serialNumberUpperBound := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberUpperBound)
+	if err != nil {
+		return nil, err
+	}
 	return &x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			CommonName: cn,
 		},

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -208,6 +208,7 @@ func TestGenSelfSignedCert(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, cn, cert.Subject.CommonName)
+	assert.Equal(t, 1, cert.SerialNumber.Sign())
 	assert.Equal(t, 2, len(cert.IPAddresses))
 	assert.Equal(t, ip1, cert.IPAddresses[0].String())
 	assert.Equal(t, ip2, cert.IPAddresses[1].String())
@@ -250,6 +251,7 @@ func TestGenSignedCert(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, cn, cert.Subject.CommonName)
+	assert.Equal(t, 1, cert.SerialNumber.Sign())
 	assert.Equal(t, 2, len(cert.IPAddresses))
 	assert.Equal(t, ip1, cert.IPAddresses[0].String())
 	assert.Equal(t, ip2, cert.IPAddresses[1].String())


### PR DESCRIPTION
All TLS certificates that are generated have a hard coded Serial Number of 1. This causes verification issues since Serial Numbers are supposed to be a positive unique number.

Example:
```
$ curl --version
curl 7.29.0 (x86_64-redhat-linux-gnu) libcurl/7.29.0 NSS/3.28.4 zlib/1.2.7 libidn/1.28 libssh2/1.4.3
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp scp sftp smtp smtps telnet tftp
Features: AsynchDNS GSS-Negotiate IDN IPv6 Largefile NTLM NTLM_WB SSL libz unix-sockets

$ curl -v --cacert /ca.crt https://test.example.com
...
* NSS error -8054 (SEC_ERROR_REUSED_ISSUER_AND_SERIAL)
* You are attempting to import a cert with the same issuer/serial as an existing cert, but that is not the same cert.
...
```

Implementation based on https://github.com/golang/go/blob/master/src/crypto/tls/generate_cert.go