### PR TITLE
Fix example for buildCustomCert

### DIFF
--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -61,7 +61,7 @@ It returns a certificate object with the following attributes:
 Example:
 
 ```
-$ca := buildCustomCert "base64-encoded-ca-key" "base64-encoded-ca-crt"
+$ca := buildCustomCert "base64-encoded-ca-crt" "base64-encoded-ca-key"
 ```
 
 Note that the returned object can be passed to the `genSignedCert` function


### PR DESCRIPTION
The example listed for `buildCustomCert` has the parameters reversed
from what is implemented in [0]. This patch set fixes the doc to match
the implementation.

[0] https://github.com/Masterminds/sprig/blob/6b2a58267f6a8b1dc8e2eb5519b984008fa85e8c/crypto.go#L166

Signed-off-by: Tin Lam <tin@irrational.io>