### PR TITLE
Extract values of dict with `values` function

### DIFF
--- a/dict.go
+++ b/dict.go
@@ -86,3 +86,12 @@ func merge(dst map[string]interface{}, srcs ...map[string]interface{}) interface
 	}
 	return dst
 }
+
+func values(dict map[string]interface{}) []interface{} {
+	values := []interface{}{}
+	for _, value := range dict {
+		values = append(values, value)
+	}
+
+	return values
+}

--- a/dict_test.go
+++ b/dict_test.go
@@ -173,3 +173,16 @@ func TestMerge(t *testing.T) {
 	}
 	assert.Equal(t, expected, dict["dst"])
 }
+
+func TestValues(t *testing.T) {
+	tests := map[string]string{
+		`{{- $d := dict "a" 1 "b" 2 }}{{ values $d | sortAlpha | join "," }}`:       "1,2",
+		`{{- $d := dict "a" "first" "b" 2 }}{{ values $d | sortAlpha | join "," }}`: "2,first",
+	}
+
+	for tpl, expect := range tests {
+		if err := runt(tpl, expect); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -195,6 +195,7 @@ These are used to manipulate dicts.
 	- keys: Get an array of all of the keys in one or more dicts.
 	- pick: Select just the given keys out of the dict, and return a new dict.
 	- omit: Return a dict without the given keys.
+	- values: Returns a list (interface{}) of all dictionary values.
 
 Math Functions:
 

--- a/docs/dicts.md
+++ b/docs/dicts.md
@@ -124,6 +124,19 @@ $new := omit $myDict "name1" "name3"
 
 The above returns `{name2: value2}`
 
+## values
+
+The `values` function is similar to `keys`, except it returns a new `list` with
+all the values of the source `dict`.
+
+```
+$vals := values $myDict
+```
+
+The above returns `list["value1", "value2", "value 3"]`. Note that the `values`
+function gives no guarantees about the result ordering- if you care about this,
+then use `sortAlpha`.
+
 ## A Note on Dict Internals
 
 A `dict` is implemented in Go as a `map[string]interface{}`. Go developers can

--- a/functions.go
+++ b/functions.go
@@ -241,6 +241,7 @@ var genericMap = map[string]interface{}{
 	"pick":   pick,
 	"omit":   omit,
 	"merge":  merge,
+	"values": values,
 
 	"append": push, "push": push,
 	"prepend": prepend,


### PR DESCRIPTION
Create the `values` function, defined on a `dict`, that is the
complement to `keys` function. `values` returns an interface{} list of
all values in a dict.