### PR TITLE
Fix substr panic

### DIFF
--- a/strings.go
+++ b/strings.go
@@ -239,14 +239,14 @@ func splitn(sep string, n int, orig string) map[string]string {
 //
 // If start is < 0, this calls string[:end].
 //
-// If start is >= 0 and end < 0, this calls string[start:]
+// If start is >= 0 and end < 0 or end bigger than s length, this calls string[start:]
 //
 // Otherwise, this calls string[start, end].
 func substring(start, end int, s string) string {
 	if start < 0 {
 		return s[:end]
 	}
-	if end < 0 {
+	if end < 0 || end > len(s) {
 		return s[start:]
 	}
 	return s[start:end]

--- a/strings_test.go
+++ b/strings_test.go
@@ -19,6 +19,13 @@ func TestSubstr(t *testing.T) {
 	}
 }
 
+func TestSubstr_shorterString(t *testing.T) {
+	tpl := `{{"foo" | substr 0 10 }}`
+	if err := runt(tpl, "foo"); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestTrunc(t *testing.T) {
 	tpl := `{{ "foooooo" | trunc 3 }}`
 	if err := runt(tpl, "foo"); err != nil {


### PR DESCRIPTION
```
panic: runtime error: slice bounds out of range [recovered]
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
text/template.errRecover(0xc420115b10)
	/go/src/text/template/exec.go:137 +0x1d4
panic(0x689de0, 0x83b570)
	/go/src/runtime/panic.go:502 +0x229
github.com/Masterminds/sprig.substring(0x0, 0xa, 0xc42016e024, 0x3, 0x0, 0x0)
	/gopath/src/github.com/Masterminds/sprig/strings.go:209 +0xbf
reflect.Value.call(0x686ea0, 0x6e24e8, 0x13, 0x6cc806, 0x4, 0xc420176140, 0x3, 0x3, 0x6cb260, 0x6b2601, ...)
	/go/src/reflect/value.go:447 +0x969
reflect.Value.Call(0x686ea0, 0x6e24e8, 0x13, 0xc420176140, 0x3, 0x3, 0x670380, 0xc420172090, 0x98)
	/go/src/reflect/value.go:308 +0xa4
text/template.(*state).evalCall(0xc420115a90, 0x688b20, 0xc4201602d0, 0x15, 0x686ea0, 0x6e24e8, 0x13, 0x706040, 0xc420160210, 0xc42016e02b, ...)
	/go/src/text/template/exec.go:667 +0x4f1
text/template.(*state).evalFunction(0xc420115a90, 0x688b20, 0xc4201602d0, 0x15, 0xc420160240, 0x706040, 0xc420160210, 0xc42015e140, 0x3, 0x4, ...)
	/go/src/text/template/exec.go:535 +0x176
text/template.(*state).evalCommand(0xc420115a90, 0x688b20, 0xc4201602d0, 0x15, 0xc420160210, 0x670380, 0xc420172090, 0x98, 0x670380, 0xc420172090, ...)
	/go/src/text/template/exec.go:432 +0x516
text/template.(*state).evalPipeline(0xc420115a90, 0x688b20, 0xc4201602d0, 0x15, 0xc4201760f0, 0x40f739, 0xc420160300, 0x30)
	/go/src/text/template/exec.go:405 +0x10f
text/template.(*state).walk(0xc420115a90, 0x688b20, 0xc4201602d0, 0x15, 0x705f80, 0xc420160270)
	/go/src/text/template/exec.go:231 +0x4a5
text/template.(*state).walk(0xc420115a90, 0x688b20, 0xc4201602d0, 0x15, 0x706180, 0xc4201601b0)
	/go/src/text/template/exec.go:239 +0x11d
text/template.(*Template).execute(0xc42015e080, 0x7042c0, 0xc4201780e0, 0x688b20, 0xc4201602d0, 0x0, 0x0)
	/go/src/text/template/exec.go:194 +0x1e6
text/template.(*Template).Execute(0xc42015e080, 0x7042c0, 0xc4201780e0, 0x688b20, 0xc4201602d0, 0xc420115b88, 0x40ff88)
	/go/src/text/template/exec.go:177 +0x53
text/template.(*Template).ExecuteTemplate(0xc42015e080, 0x7042c0, 0xc4201780e0, 0x6cfbcc, 0x8, 0x688b20, 0xc4201602d0, 0xc420115c98, 0xc4201602e0)
```
**Template to reproduce**
```
{{ "foo" | substr 0 10 }}
```
**Expected result**
```
"foo"
```