### PR TITLE
Fix 'has' documentation

### DIFF
--- a/docs/lists.md
+++ b/docs/lists.md
@@ -99,10 +99,10 @@ That would produce `[2 4]`
 Test to see if a list has a particular element.
 
 ```
-has $myList 4
+has 4 $myList
 ```
 
-The above would return `true`, while `has $myList "hello"` would return false.
+The above would return `true`, while `has "hello" $myList` would return false.
 
 ## slice
 


### PR DESCRIPTION
Fixes: https://github.com/Masterminds/sprig/issues/116
Fixes: https://github.com/Masterminds/sprig/issues/98
(Duplicate Issues)

Fix the argument order of 'has' documentation example

(Thanks @andreas-kupries for the following description of the issue:)
The list function has is implemented as `has needle haystack`
See: https://github.com/Masterminds/sprig/blob/master/list.go#L241

The documentation at https://github.com/Masterminds/sprig/blob/master/docs/lists.md
on the other hand claims the reverse: `has haystack needle`.