### PR TITLE
Update Mergo

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 770b6a1132b743dadf6a0bb5fb8bf7083b1a5209f6d6c07826234ab2a97aade9
-updated: 2018-11-02T14:53:47.937203+01:00
+hash: 03cb2df9fdf0bb084f5ddb8086a68f5c429e2c33b8df1e53ae858a2f68e27333
+updated: 2018-12-07T07:56:06.943156796-05:00
 imports:
 - name: github.com/aokoli/goutils
   version: 3391d3790d23d03408670993e957e8f408993c34
@@ -8,7 +8,7 @@ imports:
 - name: github.com/huandu/xstrings
   version: 8bbcf2f9ccb55755e748b7644164cd4bdce94c1d
 - name: github.com/imdario/mergo
-  version: 7fe0c75c13abdee74b09fcacef5ea1c6bba6a874
+  version: 9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4
 - name: github.com/Masterminds/goutils
   version: 3391d3790d23d03408670993e957e8f408993c34
 - name: github.com/Masterminds/semver

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 03cb2df9fdf0bb084f5ddb8086a68f5c429e2c33b8df1e53ae858a2f68e27333
-updated: 2018-12-07T07:56:06.943156796-05:00
+hash: 6a118404af453e4e459cc9bb3389f4badf3dd730cf755fc6d57f7915e88ea103
+updated: 2018-12-18T11:42:59.639453754-05:00
 imports:
 - name: github.com/aokoli/goutils
   version: 3391d3790d23d03408670993e957e8f408993c34
@@ -8,13 +8,13 @@ imports:
 - name: github.com/huandu/xstrings
   version: 8bbcf2f9ccb55755e748b7644164cd4bdce94c1d
 - name: github.com/imdario/mergo
-  version: 9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4
+  version: 7fe0c75c13abdee74b09fcacef5ea1c6bba6a874
 - name: github.com/Masterminds/goutils
   version: 3391d3790d23d03408670993e957e8f408993c34
 - name: github.com/Masterminds/semver
   version: 59c29afe1a994eacb71c833025ca7acf874bb1da
 - name: github.com/stretchr/testify
-  version: 04af85275a5c7ac09d16bb3b9b2e751ed45154e5
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
 - name: golang.org/x/crypto

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,5 +11,5 @@ import:
   version: v1.2.2
 - package: github.com/stretchr/testify
 - package: github.com/imdario/mergo
-  version: ~0.3.6
+  version: ~0.2.4
 - package: github.com/huandu/xstrings

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,5 +11,5 @@ import:
   version: v1.2.2
 - package: github.com/stretchr/testify
 - package: github.com/imdario/mergo
-  version: ~0.2.2
+  version: ~0.3.6
 - package: github.com/huandu/xstrings


### PR DESCRIPTION
Why I am doing this:

I am using mergo and sprig on an another project and I need to update mergo. I am encountering crashes with mergo 2 that are fixed in version 3.