### PR TITLE
Properly handle errors

### DIFF
--- a/crypto_test.go
+++ b/crypto_test.go
@@ -99,7 +99,7 @@ func TestGenPrivateKey(t *testing.T) {
 	}
 	// ensure that we can base64 encode the string
 	tpl = `{{genPrivateKey "rsa" | b64enc}}`
-	out, err = runRaw(tpl, nil)
+	_, err = runRaw(tpl, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/date.go
+++ b/date.go
@@ -52,6 +52,14 @@ func dateModify(fmt string, date time.Time) time.Time {
 	return date.Add(d)
 }
 
+func mustDateModify(fmt string, date time.Time) (time.Time, error) {
+	d, err := time.ParseDuration(fmt)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return date.Add(d), nil
+}
+
 func dateAgo(date interface{}) string {
 	var t time.Time
 
@@ -73,4 +81,8 @@ func dateAgo(date interface{}) string {
 func toDate(fmt, str string) time.Time {
 	t, _ := time.ParseInLocation(fmt, str, time.Local)
 	return t
+}
+
+func mustToDate(fmt, str string) (time.Time, error) {
+	return time.ParseInLocation(fmt, str, time.Local)
 }

--- a/defaults.go
+++ b/defaults.go
@@ -37,7 +37,7 @@ func empty(given interface{}) bool {
 	case reflect.Array, reflect.Slice, reflect.Map, reflect.String:
 		return g.Len() == 0
 	case reflect.Bool:
-		return g.Bool() == false
+		return !g.Bool()
 	case reflect.Complex64, reflect.Complex128:
 		return g.Complex() == 0
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/defaults.go
+++ b/defaults.go
@@ -67,10 +67,26 @@ func toJson(v interface{}) string {
 	return string(output)
 }
 
+func mustToJson(v interface{}) (string, error) {
+	output, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
 // toPrettyJson encodes an item into a pretty (indented) JSON string
 func toPrettyJson(v interface{}) string {
 	output, _ := json.MarshalIndent(v, "", "  ")
 	return string(output)
+}
+
+func mustToPrettyJson(v interface{}) (string, error) {
+	output, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
 }
 
 // ternary returns the first value if the last value is true, otherwise returns the second value.

--- a/dict.go
+++ b/dict.go
@@ -87,6 +87,15 @@ func merge(dst map[string]interface{}, srcs ...map[string]interface{}) interface
 	return dst
 }
 
+func mustMerge(dst map[string]interface{}, srcs ...map[string]interface{}) (interface{}, error) {
+	for _, src := range srcs {
+		if err := mergo.Merge(&dst, src); err != nil {
+			return nil, err
+		}
+	}
+	return dst, nil
+}
+
 func values(dict map[string]interface{}) []interface{} {
 	values := []interface{}{}
 	for _, value := range dict {

--- a/docs/date.md
+++ b/docs/date.md
@@ -47,7 +47,7 @@ Same as `date`, but with a timezone.
 date "2006-01-02" (now) "UTC"
 ```
 
-## dateModify
+## dateModify, mustDateModify
 
 The `dateModify` takes a modification and a date and returns the timestamp.
 
@@ -56,6 +56,7 @@ Subtract an hour and thirty minutes from the current time:
 ```
 now | date_modify "-1.5h"
 ```
+If the modification format is wrong `dateModify` will return the date unmodified. `mustDateModify` will return an error otherwise.
 
 ## htmlDate
 
@@ -74,11 +75,12 @@ Same as htmlDate, but with a timezone.
 htmlDate (now) "UTC"
 ```
 
-## toDate
+## toDate, mustToDate
 
 `toDate` converts a string to a date. The first argument is the date layout and
 the second the date string. If the string can't be convert it returns the zero
 value.
+`mustToDate` will return an error in case the string cannot be converted.
 
 This is useful when you want to convert a string date to another format
 (using pipe). The example below converts "2017-12-31" to "31/12/2017".

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -58,9 +58,10 @@ The above will first check to see if `.name` is empty. If it is not, it will ret
 that value. If it _is_ empty, `coalesce` will evaluate `.parent.name` for emptiness.
 Finally, if both `.name` and `.parent.name` are empty, it will return `Matt`.
 
-## toJson
+## toJson, mustToJson
 
-The `toJson` function encodes an item into a JSON string.
+The `toJson` function encodes an item into a JSON string. If the item cannot be converted to JSON the function will return an empty string.
+`mustToJson` will return an error in case the item cannot be encoded in JSON.
 
 ```
 toJson .Item
@@ -68,7 +69,7 @@ toJson .Item
 
 The above returns JSON string representation of `.Item`.
 
-## toPrettyJson
+## toPrettyJson, mustToPrettyJson
 
 The `toPrettyJson` function encodes an item into a pretty (indented) JSON string.
 

--- a/docs/dicts.md
+++ b/docs/dicts.md
@@ -75,7 +75,7 @@ inserted.
 A common idiom in Sprig templates is to uses `pluck... | first` to get the first
 matching key out of a collection of dictionaries.
 
-## merge
+## merge, mustMerge
 
 Merge two or more dictionaries into one, giving precedence to the dest dictionary:
 
@@ -84,6 +84,8 @@ $newdict := merge $dest $source1 $source2
 ```
 
 This is a deep merge operation.
+
+`mustMerge` will return an error in case of unsuccessful merge.
 
 ## keys
 

--- a/functions.go
+++ b/functions.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"os"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	ttemplate "text/template"
@@ -277,7 +278,7 @@ var genericMap = map[string]interface{}{
 	"fail": func(msg string) (string, error) { return "", errors.New(msg) },
 
 	// Regex
-	"regexMatch":             regexMatch,
+	"regexMatch":             func(regex string, s string) (bool, error) { return regexp.MatchString(regex, s) },
 	"regexFindAll":           regexFindAll,
 	"regexFind":              regexFind,
 	"regexReplaceAll":        regexReplaceAll,

--- a/functions.go
+++ b/functions.go
@@ -91,16 +91,18 @@ var genericMap = map[string]interface{}{
 	"hello": func() string { return "Hello!" },
 
 	// Date functions
-	"date":           date,
-	"date_in_zone":   dateInZone,
-	"date_modify":    dateModify,
-	"now":            func() time.Time { return time.Now() },
-	"htmlDate":       htmlDate,
-	"htmlDateInZone": htmlDateInZone,
-	"dateInZone":     dateInZone,
-	"dateModify":     dateModify,
-	"ago":            dateAgo,
-	"toDate":         toDate,
+	"date":             date,
+	"date_in_zone":     dateInZone,
+	"date_modify":      dateModify,
+	"must_date_modify": mustDateModify,
+	"now":              func() time.Time { return time.Now() },
+	"htmlDate":         htmlDate,
+	"htmlDateInZone":   htmlDateInZone,
+	"dateInZone":       dateInZone,
+	"mustDateModify":   mustDateModify,
+	"ago":              dateAgo,
+	"toDate":           toDate,
+	"mustToDate":       mustToDate,
 
 	// Strings
 	"abbrev":     abbrev,
@@ -201,13 +203,15 @@ var genericMap = map[string]interface{}{
 	"sortAlpha": sortAlpha,
 
 	// Defaults
-	"default":      dfault,
-	"empty":        empty,
-	"coalesce":     coalesce,
-	"compact":      compact,
-	"toJson":       toJson,
-	"toPrettyJson": toPrettyJson,
-	"ternary":      ternary,
+	"default":          dfault,
+	"empty":            empty,
+	"coalesce":         coalesce,
+	"compact":          compact,
+	"toJson":           toJson,
+	"toPrettyJson":     toPrettyJson,
+	"mustToJson":       mustToJson,
+	"mustToPrettyJson": mustToPrettyJson,
+	"ternary":          ternary,
 
 	// Reflection
 	"typeOf":     typeOf,
@@ -234,18 +238,19 @@ var genericMap = map[string]interface{}{
 	"b32dec": base32decode,
 
 	// Data Structures:
-	"tuple":  list, // FIXME: with the addition of append/prepend these are no longer immutable.
-	"list":   list,
-	"dict":   dict,
-	"set":    set,
-	"unset":  unset,
-	"hasKey": hasKey,
-	"pluck":  pluck,
-	"keys":   keys,
-	"pick":   pick,
-	"omit":   omit,
-	"merge":  merge,
-	"values": values,
+	"tuple":     list, // FIXME: with the addition of append/prepend these are no longer immutable.
+	"list":      list,
+	"dict":      dict,
+	"set":       set,
+	"unset":     unset,
+	"hasKey":    hasKey,
+	"pluck":     pluck,
+	"keys":      keys,
+	"pick":      pick,
+	"omit":      omit,
+	"merge":     merge,
+	"mustMerge": mustMerge,
+	"values":    values,
 
 	"append": push, "push": push,
 	"prepend": prepend,

--- a/functions.go
+++ b/functions.go
@@ -14,7 +14,7 @@ import (
 	"github.com/huandu/xstrings"
 )
 
-// Produce the function map.
+// FuncMap produces the function map.
 //
 // Use this to pass the functions into the template engine:
 //
@@ -24,7 +24,7 @@ func FuncMap() template.FuncMap {
 	return HtmlFuncMap()
 }
 
-// HermeticTextFuncMap returns a 'text/template'.FuncMap with only repeatable functions.
+// HermeticTxtFuncMap returns a 'text/template'.FuncMap with only repeatable functions.
 func HermeticTxtFuncMap() ttemplate.FuncMap {
 	r := TxtFuncMap()
 	for _, name := range nonhermeticFunctions {
@@ -42,7 +42,7 @@ func HermeticHtmlFuncMap() template.FuncMap {
 	return r
 }
 
-// TextFuncMap returns a 'text/template'.FuncMap
+// TxtFuncMap returns a 'text/template'.FuncMap
 func TxtFuncMap() ttemplate.FuncMap {
 	return ttemplate.FuncMap(GenericFuncMap())
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 770b6a1132b743dadf6a0bb5fb8bf7083b1a5209f6d6c07826234ab2a97aade9
-updated: 2018-11-02T14:53:47.937203+01:00
+hash: e78b6a3a3569c7b735e2104df438473e38c6cede5a31a12cfdd8386b7edb8909
+updated: 2018-12-12T23:46:15.616306+03:00
 imports:
 - name: github.com/aokoli/goutils
-  version: 3391d3790d23d03408670993e957e8f408993c34
+  version: 41ac8693c5c10a92ea1ff5ac3a7f95646f6123b0
 - name: github.com/google/uuid
   version: 064e2069ce9c359c118179501254f67d7d37ba24
 - name: github.com/huandu/xstrings
@@ -13,12 +13,14 @@ imports:
   version: 3391d3790d23d03408670993e957e8f408993c34
 - name: github.com/Masterminds/semver
   version: 59c29afe1a994eacb71c833025ca7acf874bb1da
+- name: github.com/spf13/cast
+  version: 8c9545af88b134710ab1cd196795e7f2388358d7
 - name: github.com/stretchr/testify
-  version: 04af85275a5c7ac09d16bb3b9b2e751ed45154e5
+  version: 5b93e2dc01fd8fbf32aa74a198b0ebe78f6f6b6f
   subpackages:
   - assert
 - name: golang.org/x/crypto
-  version: 4d3f4d9ffa16a13f451c3b2999e9c49e9750bf06
+  version: 505ab145d0a99da450461ae2c1a9f6cd10d1f447
   subpackages:
   - pbkdf2
   - scrypt

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,3 +13,5 @@ import:
 - package: github.com/imdario/mergo
   version: ~0.2.2
 - package: github.com/huandu/xstrings
+- package: github.com/spf13/cast
+  version: ^1.3.0

--- a/list.go
+++ b/list.go
@@ -1,7 +1,6 @@
 package sprig
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -241,7 +240,7 @@ func without(list interface{}, omit ...interface{}) ([]interface{}, error) {
 
 func has(needle interface{}, haystack interface{}) (bool, error) {
 	if haystack == nil {
-		return false, errors.New("The haystack is empty")
+		return false, nil
 	}
 	tp := reflect.TypeOf(haystack).Kind()
 	switch tp {

--- a/list.go
+++ b/list.go
@@ -14,7 +14,7 @@ func list(v ...interface{}) []interface{} {
 	return v
 }
 
-func push(list interface{}, v interface{}) []interface{} {
+func push(list interface{}, v interface{}) ([]interface{}, error) {
 	tp := reflect.TypeOf(list).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -26,14 +26,14 @@ func push(list interface{}, v interface{}) []interface{} {
 			nl[i] = l2.Index(i).Interface()
 		}
 
-		return append(nl, v)
+		return append(nl, v), nil
 
 	default:
-		panic(fmt.Sprintf("Cannot push on type %s", tp))
+		return nil, fmt.Errorf("Cannot push on type %s", tp)
 	}
 }
 
-func prepend(list interface{}, v interface{}) []interface{} {
+func prepend(list interface{}, v interface{}) ([]interface{}, error) {
 	//return append([]interface{}{v}, list...)
 
 	tp := reflect.TypeOf(list).Kind()
@@ -47,14 +47,14 @@ func prepend(list interface{}, v interface{}) []interface{} {
 			nl[i] = l2.Index(i).Interface()
 		}
 
-		return append([]interface{}{v}, nl...)
+		return append([]interface{}{v}, nl...), nil
 
 	default:
-		panic(fmt.Sprintf("Cannot prepend on type %s", tp))
+		return nil, fmt.Errorf("Cannot prepend on type %s", tp)
 	}
 }
 
-func last(list interface{}) interface{} {
+func last(list interface{}) (interface{}, error) {
 	tp := reflect.TypeOf(list).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -62,16 +62,16 @@ func last(list interface{}) interface{} {
 
 		l := l2.Len()
 		if l == 0 {
-			return nil
+			return nil, nil
 		}
 
-		return l2.Index(l - 1).Interface()
+		return l2.Index(l - 1).Interface(), nil
 	default:
-		panic(fmt.Sprintf("Cannot find last on type %s", tp))
+		return nil, fmt.Errorf("Cannot find last on type %s", tp)
 	}
 }
 
-func first(list interface{}) interface{} {
+func first(list interface{}) (interface{}, error) {
 	tp := reflect.TypeOf(list).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -79,16 +79,16 @@ func first(list interface{}) interface{} {
 
 		l := l2.Len()
 		if l == 0 {
-			return nil
+			return nil, nil
 		}
 
-		return l2.Index(0).Interface()
+		return l2.Index(0).Interface(), nil
 	default:
-		panic(fmt.Sprintf("Cannot find first on type %s", tp))
+		return nil, fmt.Errorf("Cannot find first on type %s", tp)
 	}
 }
 
-func rest(list interface{}) []interface{} {
+func rest(list interface{}) ([]interface{}, error) {
 	tp := reflect.TypeOf(list).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -96,7 +96,7 @@ func rest(list interface{}) []interface{} {
 
 		l := l2.Len()
 		if l == 0 {
-			return nil
+			return nil, nil
 		}
 
 		nl := make([]interface{}, l-1)
@@ -104,13 +104,13 @@ func rest(list interface{}) []interface{} {
 			nl[i-1] = l2.Index(i).Interface()
 		}
 
-		return nl
+		return nl, nil
 	default:
-		panic(fmt.Sprintf("Cannot find rest on type %s", tp))
+		return nil, fmt.Errorf("Cannot find rest on type %s", tp)
 	}
 }
 
-func initial(list interface{}) []interface{} {
+func initial(list interface{}) ([]interface{}, error) {
 	tp := reflect.TypeOf(list).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -118,7 +118,7 @@ func initial(list interface{}) []interface{} {
 
 		l := l2.Len()
 		if l == 0 {
-			return nil
+			return nil, nil
 		}
 
 		nl := make([]interface{}, l-1)
@@ -126,9 +126,9 @@ func initial(list interface{}) []interface{} {
 			nl[i] = l2.Index(i).Interface()
 		}
 
-		return nl
+		return nl, nil
 	default:
-		panic(fmt.Sprintf("Cannot find initial on type %s", tp))
+		return nil, fmt.Errorf("Cannot find initial on type %s", tp)
 	}
 }
 
@@ -144,7 +144,7 @@ func sortAlpha(list interface{}) []string {
 	return []string{strval(list)}
 }
 
-func reverse(v interface{}) []interface{} {
+func reverse(v interface{}) ([]interface{}, error) {
 	tp := reflect.TypeOf(v).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -157,13 +157,13 @@ func reverse(v interface{}) []interface{} {
 			nl[l-i-1] = l2.Index(i).Interface()
 		}
 
-		return nl
+		return nl, nil
 	default:
-		panic(fmt.Sprintf("Cannot find reverse on type %s", tp))
+		return nil, fmt.Errorf("Cannot find reverse on type %s", tp)
 	}
 }
 
-func compact(list interface{}) []interface{} {
+func compact(list interface{}) ([]interface{}, error) {
 	tp := reflect.TypeOf(list).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -179,13 +179,13 @@ func compact(list interface{}) []interface{} {
 			}
 		}
 
-		return nl
+		return nl, nil
 	default:
-		panic(fmt.Sprintf("Cannot compact on type %s", tp))
+		return nil, fmt.Errorf("Cannot compact on type %s", tp)
 	}
 }
 
-func uniq(list interface{}) []interface{} {
+func uniq(list interface{}) ([]interface{}, error) {
 	tp := reflect.TypeOf(list).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -201,9 +201,9 @@ func uniq(list interface{}) []interface{} {
 			}
 		}
 
-		return dest
+		return dest, nil
 	default:
-		panic(fmt.Sprintf("Cannot find uniq on type %s", tp))
+		return nil, fmt.Errorf("Cannot find uniq on type %s", tp)
 	}
 }
 
@@ -216,7 +216,7 @@ func inList(haystack []interface{}, needle interface{}) bool {
 	return false
 }
 
-func without(list interface{}, omit ...interface{}) []interface{} {
+func without(list interface{}, omit ...interface{}) ([]interface{}, error) {
 	tp := reflect.TypeOf(list).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -232,13 +232,13 @@ func without(list interface{}, omit ...interface{}) []interface{} {
 			}
 		}
 
-		return res
+		return res, nil
 	default:
-		panic(fmt.Sprintf("Cannot find without on type %s", tp))
+		return nil, fmt.Errorf("Cannot find without on type %s", tp)
 	}
 }
 
-func has(needle interface{}, haystack interface{}) bool {
+func has(needle interface{}, haystack interface{}) (bool, error) {
 	tp := reflect.TypeOf(haystack).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -248,13 +248,13 @@ func has(needle interface{}, haystack interface{}) bool {
 		for i := 0; i < l; i++ {
 			item = l2.Index(i).Interface()
 			if reflect.DeepEqual(needle, item) {
-				return true
+				return true, nil
 			}
 		}
 
-		return false
+		return false, nil
 	default:
-		panic(fmt.Sprintf("Cannot find has on type %s", tp))
+		return false, fmt.Errorf("Cannot find has on type %s", tp)
 	}
 }
 
@@ -263,7 +263,7 @@ func has(needle interface{}, haystack interface{}) bool {
 // slice $list 0 3 -> list[0:3] = list[:3]
 // slice $list 3 5 -> list[3:5]
 // slice $list 3   -> list[3:5] = list[3:]
-func slice(list interface{}, indices ...interface{}) interface{} {
+func slice(list interface{}, indices ...interface{}) (interface{}, error) {
 	tp := reflect.TypeOf(list).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:
@@ -271,7 +271,7 @@ func slice(list interface{}, indices ...interface{}) interface{} {
 
 		l := l2.Len()
 		if l == 0 {
-			return nil
+			return nil, nil
 		}
 
 		var start, end int
@@ -284,8 +284,8 @@ func slice(list interface{}, indices ...interface{}) interface{} {
 			end = toInt(indices[1])
 		}
 
-		return l2.Slice(start, end).Interface()
+		return l2.Slice(start, end).Interface(), nil
 	default:
-		panic(fmt.Sprintf("list should be type of slice or array but %s", tp))
+		return nil, fmt.Errorf("list should be type of slice or array but %s", tp)
 	}
 }

--- a/numeric.go
+++ b/numeric.go
@@ -27,7 +27,7 @@ func toFloat64(v interface{}) float64 {
 	case reflect.Float32, reflect.Float64:
 		return val.Float()
 	case reflect.Bool:
-		if val.Bool() == true {
+		if val.Bool() {
 			return 1
 		}
 		return 0
@@ -67,7 +67,7 @@ func toInt64(v interface{}) int64 {
 	case reflect.Float32, reflect.Float64:
 		return int64(val.Float())
 	case reflect.Bool:
-		if val.Bool() == true {
+		if val.Bool() {
 			return 1
 		}
 		return 0
@@ -138,10 +138,10 @@ func ceil(a interface{}) float64 {
 	return math.Ceil(aa)
 }
 
-func round(a interface{}, p int, r_opt ...float64) float64 {
+func round(a interface{}, p int, rOpt ...float64) float64 {
 	roundOn := .5
-	if len(r_opt) > 0 {
-		roundOn = r_opt[0]
+	if len(rOpt) > 0 {
+		roundOn = rOpt[0]
 	}
 	val := toFloat64(a)
 	places := toFloat64(p)

--- a/numeric.go
+++ b/numeric.go
@@ -2,78 +2,22 @@ package sprig
 
 import (
 	"math"
-	"reflect"
-	"strconv"
+
+	"github.com/spf13/cast"
 )
 
 // toFloat64 converts 64-bit floats
 func toFloat64(v interface{}) float64 {
-	if str, ok := v.(string); ok {
-		iv, err := strconv.ParseFloat(str, 64)
-		if err != nil {
-			return 0
-		}
-		return iv
-	}
-
-	val := reflect.Indirect(reflect.ValueOf(v))
-	switch val.Kind() {
-	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
-		return float64(val.Int())
-	case reflect.Uint8, reflect.Uint16, reflect.Uint32:
-		return float64(val.Uint())
-	case reflect.Uint, reflect.Uint64:
-		return float64(val.Uint())
-	case reflect.Float32, reflect.Float64:
-		return val.Float()
-	case reflect.Bool:
-		if val.Bool() {
-			return 1
-		}
-		return 0
-	default:
-		return 0
-	}
+	return cast.ToFloat64(v)
 }
 
 func toInt(v interface{}) int {
-	//It's not optimal. Bud I don't want duplicate toInt64 code.
-	return int(toInt64(v))
+	return cast.ToInt(v)
 }
 
 // toInt64 converts integer types to 64-bit integers
 func toInt64(v interface{}) int64 {
-	if str, ok := v.(string); ok {
-		iv, err := strconv.ParseInt(str, 10, 64)
-		if err != nil {
-			return 0
-		}
-		return iv
-	}
-
-	val := reflect.Indirect(reflect.ValueOf(v))
-	switch val.Kind() {
-	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
-		return val.Int()
-	case reflect.Uint8, reflect.Uint16, reflect.Uint32:
-		return int64(val.Uint())
-	case reflect.Uint, reflect.Uint64:
-		tv := val.Uint()
-		if tv <= math.MaxInt64 {
-			return int64(tv)
-		}
-		// TODO: What is the sensible thing to do here?
-		return math.MaxInt64
-	case reflect.Float32, reflect.Float64:
-		return int64(val.Float())
-	case reflect.Bool:
-		if val.Bool() {
-			return 1
-		}
-		return 0
-	default:
-		return 0
-	}
+	return cast.ToInt64(v)
 }
 
 func max(a interface{}, i ...interface{}) int64 {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -29,7 +29,7 @@ func TestKindOf(t *testing.T) {
 		t.Error(err)
 	}
 
-	var f3 *fixtureTO = nil
+	var f3 *fixtureTO
 	if err := runtv(tpl, "ptr", f3); err != nil {
 		t.Error(err)
 	}

--- a/regex.go
+++ b/regex.go
@@ -4,32 +4,42 @@ import (
 	"regexp"
 )
 
-func regexMatch(regex string, s string) bool {
-	match, _ := regexp.MatchString(regex, s)
-	return match
+func regexFindAll(regex string, s string, n int) ([]string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return []string{}, err
+	}
+	return r.FindAllString(s, n), nil
 }
 
-func regexFindAll(regex string, s string, n int) []string {
-	r := regexp.MustCompile(regex)
-	return r.FindAllString(s, n)
+func regexFind(regex string, s string) (string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return "", err
+	}
+	return r.FindString(s), nil
 }
 
-func regexFind(regex string, s string) string {
-	r := regexp.MustCompile(regex)
-	return r.FindString(s)
+func regexReplaceAll(regex string, s string, repl string) (string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return "", err
+	}
+	return r.ReplaceAllString(s, repl), nil
 }
 
-func regexReplaceAll(regex string, s string, repl string) string {
-	r := regexp.MustCompile(regex)
-	return r.ReplaceAllString(s, repl)
+func regexReplaceAllLiteral(regex string, s string, repl string) (string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return "", err
+	}
+	return r.ReplaceAllLiteralString(s, repl), nil
 }
 
-func regexReplaceAllLiteral(regex string, s string, repl string) string {
-	r := regexp.MustCompile(regex)
-	return r.ReplaceAllLiteralString(s, repl)
-}
-
-func regexSplit(regex string, s string, n int) []string {
-	r := regexp.MustCompile(regex)
-	return r.Split(s, n)
+func regexSplit(regex string, s string, n int) ([]string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return []string{}, err
+	}
+	return r.Split(s, n), nil
 }

--- a/regex_test.go
+++ b/regex_test.go
@@ -6,56 +6,115 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRegexMatch(t *testing.T) {
-	regex := "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
-
-	assert.True(t, regexMatch(regex, "test@acme.com"))
-	assert.True(t, regexMatch(regex, "Test@Acme.Com"))
-	assert.False(t, regexMatch(regex, "test"))
-	assert.False(t, regexMatch(regex, "test.com"))
-	assert.False(t, regexMatch(regex, "test@acme"))
-}
-
 func TestRegexFindAll(t *testing.T) {
-	regex := "a{2}"
-	assert.Equal(t, 1, len(regexFindAll(regex, "aa", -1)))
-	assert.Equal(t, 1, len(regexFindAll(regex, "aaaaaaaa", 1)))
-	assert.Equal(t, 2, len(regexFindAll(regex, "aaaa", -1)))
-	assert.Equal(t, 0, len(regexFindAll(regex, "none", -1)))
+	type args struct {
+		regex, s string
+		n        int
+	}
+	cases := []struct {
+		expected int
+		args     args
+	}{
+		{1, args{"a{2}", "aa", -1}},
+		{1, args{"a{2}", "aaaaaaaa", 1}},
+		{2, args{"a{2}", "aaaa", -1}},
+		{0, args{"a{2}", "none", -1}},
+	}
+
+	for _, c := range cases {
+		res, err := regexFindAll(c.args.regex, c.args.s, c.args.n)
+		if err != nil {
+			t.Errorf("regexFindAll test case %v failed with err %s", c, err)
+		}
+		assert.Equal(t, c.expected, len(res), "case %#v", c.args)
+	}
 }
 
 func TestRegexFindl(t *testing.T) {
-	regex := "fo.?"
-	assert.Equal(t, "foo", regexFind(regex, "foorbar"))
-	assert.Equal(t, "foo", regexFind(regex, "foo foe fome"))
-	assert.Equal(t, "", regexFind(regex, "none"))
+	type args struct{ regex, s string }
+	cases := []struct {
+		expected string
+		args     args
+	}{
+		{"foo", args{"fo.?", "foorbar"}},
+		{"foo", args{"fo.?", "foo foe fome"}},
+		{"", args{"fo.?", "none"}},
+	}
+
+	for _, c := range cases {
+		res, err := regexFind(c.args.regex, c.args.s)
+		if err != nil {
+			t.Errorf("regexFind test case %v failed with err %s", c, err)
+		}
+		assert.Equal(t, c.expected, res, "case %#v", c.args)
+	}
 }
 
 func TestRegexReplaceAll(t *testing.T) {
-	regex := "a(x*)b"
-	assert.Equal(t, "-T-T-", regexReplaceAll(regex, "-ab-axxb-", "T"))
-	assert.Equal(t, "--xx-", regexReplaceAll(regex, "-ab-axxb-", "$1"))
-	assert.Equal(t, "---", regexReplaceAll(regex, "-ab-axxb-", "$1W"))
-	assert.Equal(t, "-W-xxW-", regexReplaceAll(regex, "-ab-axxb-", "${1}W"))
+	type args struct{ regex, s, repl string }
+	cases := []struct {
+		expected string
+		args     args
+	}{
+		{"-T-T-", args{"a(x*)b", "-ab-axxb-", "T"}},
+		{"--xx-", args{"a(x*)b", "-ab-axxb-", "$1"}},
+		{"---", args{"a(x*)b", "-ab-axxb-", "$1W"}},
+		{"-W-xxW-", args{"a(x*)b", "-ab-axxb-", "${1}W"}},
+	}
+
+	for _, c := range cases {
+		res, err := regexReplaceAll(c.args.regex, c.args.s, c.args.repl)
+		if err != nil {
+			t.Errorf("regexReplaceAll test case %v failed with err %s", c, err)
+		}
+		assert.Equal(t, c.expected, res, "case %#v", c.args)
+	}
 }
 
 func TestRegexReplaceAllLiteral(t *testing.T) {
-	regex := "a(x*)b"
-	assert.Equal(t, "-T-T-", regexReplaceAllLiteral(regex, "-ab-axxb-", "T"))
-	assert.Equal(t, "-$1-$1-", regexReplaceAllLiteral(regex, "-ab-axxb-", "$1"))
-	assert.Equal(t, "-${1}-${1}-", regexReplaceAllLiteral(regex, "-ab-axxb-", "${1}"))
+	type args struct{ regex, s, repl string }
+	cases := []struct {
+		expected string
+		args     args
+	}{
+		{"-T-T-", args{"a(x*)b", "-ab-axxb-", "T"}},
+		{"-$1-$1-", args{"a(x*)b", "-ab-axxb-", "$1"}},
+		{"-${1}-${1}-", args{"a(x*)b", "-ab-axxb-", "${1}"}},
+	}
+
+	for _, c := range cases {
+		res, err := regexReplaceAllLiteral(c.args.regex, c.args.s, c.args.repl)
+		if err != nil {
+			t.Errorf("regexReplaceAllLiteral test case %v failed with err %s", c, err)
+		}
+		assert.Equal(t, c.expected, res, "case %#v", c.args)
+	}
 }
 
 func TestRegexSplit(t *testing.T) {
-	regex := "a"
-	assert.Equal(t, 4, len(regexSplit(regex, "banana", -1)))
-	assert.Equal(t, 0, len(regexSplit(regex, "banana", 0)))
-	assert.Equal(t, 1, len(regexSplit(regex, "banana", 1)))
-	assert.Equal(t, 2, len(regexSplit(regex, "banana", 2)))
+	type args struct {
+		regex, s string
+		n        int
+	}
+	cases := []struct {
+		expected int
+		args     args
+	}{
+		{4, args{"a", "banana", -1}},
+		{0, args{"a", "banana", 0}},
+		{1, args{"a", "banana", 1}},
+		{2, args{"a", "banana", 2}},
+		{2, args{"z+", "pizza", -1}},
+		{0, args{"z+", "pizza", 0}},
+		{1, args{"z+", "pizza", 1}},
+		{2, args{"z+", "pizza", 2}},
+	}
 
-	regex = "z+"
-	assert.Equal(t, 2, len(regexSplit(regex, "pizza", -1)))
-	assert.Equal(t, 0, len(regexSplit(regex, "pizza", 0)))
-	assert.Equal(t, 1, len(regexSplit(regex, "pizza", 1)))
-	assert.Equal(t, 2, len(regexSplit(regex, "pizza", 2)))
+	for _, c := range cases {
+		res, err := regexSplit(c.args.regex, c.args.s, c.args.n)
+		if err != nil {
+			t.Errorf("regexSplit test case %v failed with err %s", c, err)
+		}
+		assert.Equal(t, c.expected, len(res), "case %#v", c.args)
+	}
 }


### PR DESCRIPTION
* tried to satisfy the god of linters;
* replaced explicit and "inherited" panics with error returns (fixes #125), this actually makes much more sense;
* introduced new functions: `mustDateModify`, `mustToDate`, `mustToJson`, `mustToPrettyJson`, `mustMerge` (fixes #115);
* replaced type cast functions with spf13/cast to DRY and not re-invent anything. If for some reason you find this change should be reverted please let me know
