### PR TITLE
Surface cryptographically secure random strings from goutils

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -151,6 +151,25 @@ initials "First Try"
 
 The above returns `FT`
 
+## cryptoRandAlphaNum, cryptoRandAlpha, cryptoRandNumeric, and cryptoRandAscii
+
+These four functions generate cryptographically secure (uses ```crypto/rand```)
+random strings, but with different base character sets. They should be used for
+generating random strings to be used for security purposes:
+
+- `cryptoRandAlphaNum` uses `0-9a-zA-Z`
+- `cryptoRandAlpha` uses `a-zA-Z`
+- `cryptoRandNumeric` uses `0-9`
+- `cryptoRandAscii` uses all printable ASCII characters
+
+Each of them takes one parameter: the integer length of the string.
+
+```
+cryptoRandNumeric 30
+```
+
+The above will produce a cryptographically secure random string with thirty digits.
+
 ## randAlphaNum, randAlpha, randNumeric, and randAscii
 
 These four functions generate random strings, but with different base character

--- a/functions.go
+++ b/functions.go
@@ -10,7 +10,7 @@ import (
 	ttemplate "text/template"
 	"time"
 
-	util "github.com/aokoli/goutils"
+	util "github.com/Masterminds/goutils"
 	"github.com/huandu/xstrings"
 )
 

--- a/functions.go
+++ b/functions.go
@@ -75,6 +75,10 @@ var nonhermeticFunctions = []string{
 	"dateModify",
 
 	// Strings
+	"cryptoRandAlphaNum",
+	"cryptoRandAlpha",
+	"cryptoRandAscii",
+	"cryptoRandNumeric",
 	"randAlphaNum",
 	"randAlpha",
 	"randAscii",
@@ -121,6 +125,10 @@ var genericMap = map[string]interface{}{
 	"trimPrefix":   func(a, b string) string { return strings.TrimPrefix(b, a) },
 	"nospace":      util.DeleteWhiteSpace,
 	"initials":     initials,
+	"cryptoRandAlphaNum": cryptoRandAlphaNumeric,
+	"cryptoRandAlpha":    cryptoRandAlpha,
+	"cryptoRandAscii":    cryptoRandAscii,
+	"cryptoRandNumeric":  cryptoRandNumeric,
 	"randAlphaNum": randAlphaNumeric,
 	"randAlpha":    randAlpha,
 	"randAscii":    randAscii,

--- a/functions_test.go
+++ b/functions_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/aokoli/goutils"
+	"github.com/Masterminds/goutils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
 hash: f9e13000d2d99ee559a37e9b35d310bab6687b64141e98bd122e772c7e1da63a
 updated: 2019-01-03T16:14:49.53019-07:00
 imports:
-- name: github.com/aokoli/goutils
-  version: 9c37978a95bd5c709a15883b6242714ea6709e64
 - name: github.com/google/uuid
   version: 064e2069ce9c359c118179501254f67d7d37ba24
 - name: github.com/huandu/xstrings

--- a/strings.go
+++ b/strings.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	util "github.com/aokoli/goutils"
+	util "github.com/Masterminds/goutils"
 )
 
 func base64encode(v string) string {
@@ -53,6 +53,26 @@ func abbrevboth(left, right int, s string) string {
 func initials(s string) string {
 	// Wrap this just to eliminate the var args, which templates don't do well.
 	return util.Initials(s)
+}
+
+func cryptoRandAlphaNumeric(count int) string {
+	r, _ := util.CryptoRandomAlphaNumeric(count)
+	return r
+}
+
+func cryptoRandAlpha(count int) string {
+	r, _ := util.CryptoRandomAlphabetic(count)
+	return r
+}
+
+func cryptoRandAscii(count int) string {
+	r, _ := util.CryptoRandomAscii(count)
+	return r
+}
+
+func cryptoRandNumeric(count int) string {
+	r, _ := util.CryptoRandomNumeric(count)
+	return r
 }
 
 func randAlphaNumeric(count int) string {

--- a/strings_test.go
+++ b/strings_test.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"unicode/utf8"
 
-	"github.com/aokoli/goutils"
+	"github.com/Masterminds/goutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -170,6 +171,30 @@ func TestGoutils(t *testing.T) {
 		if err := runt(k, v); err != nil {
 			t.Errorf("Error on tpl %q: %s", k, err)
 		}
+	}
+}
+
+func TestCryptoRandom(t *testing.T) {
+	// These tests have no predictable character sequence. No checks for exact string output are necessary.
+
+	// {{cryptoRandAlphaNum 5}} should yield five random characters
+	if x, _ := runRaw(`{{cryptoRandAlphaNum 5}}`, nil); utf8.RuneCountInString(x) != 5 {
+		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
+	}
+
+	// {{cryptoRandAlpha 5}} should yield five random characters
+	if x, _ := runRaw(`{{cryptoRandAlpha 5}}`, nil); utf8.RuneCountInString(x) != 5 {
+		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
+	}
+
+	// {{cryptoRandAscii 5}} should yield five random characters
+	if x, _ := runRaw(`{{cryptoRandAscii 5}}`, nil); utf8.RuneCountInString(x) != 5 {
+		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
+	}
+
+	// {{cryptoRandNumeric 5}} should yield five random characters
+	if x, _ := runRaw(`{{cryptoRandNumeric 5}}`, nil); utf8.RuneCountInString(x) != 5 {
+		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
 	}
 }
 


### PR DESCRIPTION
This PR surfaces the random string functions that utilize ```crypto/rand``` that were added to ```goutils``` here: https://github.com/Masterminds/goutils/pull/25. This will allow Go templates to utilize random strings that have been generated in a cryptographically secure way.

I made the functions accessible by surfacing them through ```strings.go```. I bounced back and forth between thinking they should be in ```strings.go``` and ```crypto.go``` a few times. If you think they should be made available via ```crypto.go``` instead, just let me know.

@technosophos 