### PR TITLE
Fix/dict merge issue

### DIFF
--- a/dict.go
+++ b/dict.go
@@ -87,6 +87,16 @@ func merge(dst map[string]interface{}, srcs ...map[string]interface{}) interface
 	return dst
 }
 
+func mergeOverwrite(dst map[string]interface{}, srcs ...map[string]interface{}) interface{} {
+  for _, src := range srcs {
+		if err := mergo.MergeWithOverwrite(&dst, src); err != nil {
+			// Swallow errors inside of a template.
+			return ""
+		}
+  }
+  return dst
+}
+
 func values(dict map[string]interface{}) []interface{} {
 	values := []interface{}{}
 	for _, value := range dict {

--- a/dict_test.go
+++ b/dict_test.go
@@ -142,6 +142,9 @@ func TestMerge(t *testing.T) {
 			"g": []int{6, 7},
 			"i": "aye",
 			"j": "jay",
+			"k": map[string]interface{}{
+				"l": false,
+			},
 		},
 		"dst": map[string]interface{}{
 			"a": "one",
@@ -151,6 +154,9 @@ func TestMerge(t *testing.T) {
 			},
 			"g": []int{8, 9},
 			"i": "eye",
+			"k": map[string]interface{}{
+				"l": true,
+			},
 		},
 	}
 	tpl := `{{merge .dst .src1 .src2}}`
@@ -170,6 +176,66 @@ func TestMerge(t *testing.T) {
 		"h": 10,          // merged from src2
 		"i": "eye",       // overridden twice
 		"j": "jay",       // overridden and merged
+		"k": map[string]interface{}{
+			"l": true,      // overriden
+		},
+	}
+	assert.Equal(t, expected, dict["dst"])
+}
+
+func TestMergeOverwrite(t *testing.T) {
+	dict := map[string]interface{}{
+		"src2": map[string]interface{}{
+			"h": 10,
+			"i": "i",
+			"j": "j",
+		},
+		"src1": map[string]interface{}{
+			"a": 1,
+			"b": 2,
+			"d": map[string]interface{}{
+				"e": "four",
+			},
+			"g": []int{6, 7},
+			"i": "aye",
+			"j": "jay",
+			"k": map[string]interface{}{
+				"l": false,
+			},
+		},
+		"dst": map[string]interface{}{
+			"a": "one",
+			"c": 3,
+			"d": map[string]interface{}{
+				"f": 5,
+			},
+			"g": []int{8, 9},
+			"i": "eye",
+			"k": map[string]interface{}{
+				"l": true,
+			},
+		},
+	}
+	tpl := `{{mergeOverwrite .dst .src1 .src2}}`
+	_, err := runRaw(tpl, dict)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := map[string]interface{}{
+		"a": 1,     // key overwritten from src1
+		"b": 2,     // merged from src1
+		"c": 3,     // merged from dst
+		"d": map[string]interface{}{ // deep merge
+			"e": "four",
+			"f": 5,
+		},
+		"g": []int{6, 7}, // overwritten src1 wins
+		"h": 10,          // merged from src2
+		"i": "i",         // overwritten twice src2 wins
+		"j": "j",         // overwritten twice src2 wins
+		"k": map[string]interface{} { // deep merge
+			"l": false, // overwritten src1 wins
+		},
 	}
 	assert.Equal(t, expected, dict["dst"])
 }

--- a/docs/dicts.md
+++ b/docs/dicts.md
@@ -85,6 +85,39 @@ $newdict := merge $dest $source1 $source2
 
 This is a deep merge operation.
 
+## mergeOverwrite
+
+Merge two or more dictionaries into one, giving precedence from **right to left**, effectively
+overwriting values in the dest dictionary:
+
+Given:
+
+```
+dst:
+  default: default
+  overwrite: me
+  key: true
+
+src:
+  overwrite: overwritten
+  key: false
+```
+
+will result in:
+
+```
+newdict:
+  default: default
+  overwrite: overwritten
+  key: false
+```
+
+```
+$newdict := mergeOverwrite $dest $source1 $source2
+```
+
+This is a deep merge operation.
+
 ## keys
 
 The `keys` function will return a `list` of all of the keys in one or more `dict`

--- a/functions.go
+++ b/functions.go
@@ -245,6 +245,7 @@ var genericMap = map[string]interface{}{
 	"pick":   pick,
 	"omit":   omit,
 	"merge":  merge,
+	"mergeOverwrite": mergeOverwrite,
 	"values": values,
 
 	"append": push, "push": push,

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f9e13000d2d99ee559a37e9b35d310bab6687b64141e98bd122e772c7e1da63a
-updated: 2019-01-03T16:14:49.53019-07:00
+hash: 6a3f4f83c443958625ff1bafadd95c96d20d729f34e8e8c2fa72782194fc4807
+updated: 2019-01-30T20:16:27.780177826+01:00
 imports:
 - name: github.com/aokoli/goutils
   version: 9c37978a95bd5c709a15883b6242714ea6709e64
@@ -8,7 +8,7 @@ imports:
 - name: github.com/huandu/xstrings
   version: f02667b379e2fb5916c3cda2cf31e0eb885d79f8
 - name: github.com/imdario/mergo
-  version: 7fe0c75c13abdee74b09fcacef5ea1c6bba6a874
+  version: 7c29201646fa3de8506f701213473dd407f19646
 - name: github.com/Masterminds/goutils
   version: 41ac8693c5c10a92ea1ff5ac3a7f95646f6123b0
 - name: github.com/Masterminds/semver

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,6 +11,6 @@ import:
   version: v1.2.2
 - package: github.com/stretchr/testify
 - package: github.com/imdario/mergo
-  version: ~0.2.2
+  version: ~0.3.7
 - package: github.com/huandu/xstrings
   version: ^1.2


### PR DESCRIPTION
As pointed out in #134 in [my comment](https://github.com/Masterminds/sprig/issues/134#issuecomment-458999247) sprig could benefit from a `{{ mergeOverwrite .dst .src }}` function that merges from **right into left** and overwrites values properly.

In some other domains/languages this is the default deep merge behaviour. In go / mergo it seems to be named `mergeOverwrite`, hence I choose the sprig function name to be the same.

This addition could dramatically improve helm templating, since it is currently not possible to properly inherit `.Values` from the default `.Values` of dependent chart, and use a dependency as a template providing base-chart. See [this issue at helm/helm](https://github.com/helm/helm/issues/5238) for more information.