### PR TITLE
Gracefully handle nil list in "has" function

### DIFF
--- a/list.go
+++ b/list.go
@@ -239,6 +239,9 @@ func without(list interface{}, omit ...interface{}) []interface{} {
 }
 
 func has(needle interface{}, haystack interface{}) bool {
+	if haystack == nil {
+		return false
+	}
 	tp := reflect.TypeOf(haystack).Kind()
 	switch tp {
 	case reflect.Slice, reflect.Array:

--- a/list_test.go
+++ b/list_test.go
@@ -150,6 +150,7 @@ func TestHas(t *testing.T) {
 		`{{ list 1 2 3 | has 1 }}`:                          `true`,
 		`{{ list 1 2 3 | has 4 }}`:                          `false`,
 		`{{ regexSplit "/" "foo/bar/baz" -1 | has "bar" }}`: `true`,
+		`{{ has "bar" nil }}`:                               `false`,
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))


### PR DESCRIPTION
When iterating through multiple lists, possibly including nil entries, it's useful for the "has" function to gracefully handle nil values.

For example, instead of panicking, the following template should return false, since trivially, a value cannot exist in an empty and/or nil list:
`{{ has "bar" nil }}`

This pull request adds a check for this trivial case before the reflection, so the function returns false instead of triggering a panic.