### PR TITLE
Make random string functions use crypto by default

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -162,7 +162,7 @@ The above returns `FT`
 ## randAlphaNum, randAlpha, randNumeric, and randAscii
 
 These four functions generate cryptographically secure (uses ```crypto/rand```)
-random strings, but with different base character sets.:
+random strings, but with different base character sets:
 
 - `randAlphaNum` uses `0-9a-zA-Z`
 - `randAlpha` uses `a-zA-Z`

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -159,29 +159,10 @@ initials "First Try"
 
 The above returns `FT`
 
-## cryptoRandAlphaNum, cryptoRandAlpha, cryptoRandNumeric, and cryptoRandAscii
-
-These four functions generate cryptographically secure (uses ```crypto/rand```)
-random strings, but with different base character sets. They should be used for
-generating random strings to be used for security purposes:
-
-- `cryptoRandAlphaNum` uses `0-9a-zA-Z`
-- `cryptoRandAlpha` uses `a-zA-Z`
-- `cryptoRandNumeric` uses `0-9`
-- `cryptoRandAscii` uses all printable ASCII characters
-
-Each of them takes one parameter: the integer length of the string.
-
-```
-cryptoRandNumeric 30
-```
-
-The above will produce a cryptographically secure random string with thirty digits.
-
 ## randAlphaNum, randAlpha, randNumeric, and randAscii
 
-These four functions generate random strings, but with different base character
-sets:
+These four functions generate cryptographically secure (uses ```crypto/rand```)
+random strings, but with different base character sets.:
 
 - `randAlphaNum` uses `0-9a-zA-Z`
 - `randAlpha` uses `a-zA-Z`

--- a/functions.go
+++ b/functions.go
@@ -75,10 +75,6 @@ var nonhermeticFunctions = []string{
 	"dateModify",
 
 	// Strings
-	"cryptoRandAlphaNum",
-	"cryptoRandAlpha",
-	"cryptoRandAscii",
-	"cryptoRandNumeric",
 	"randAlphaNum",
 	"randAlpha",
 	"randAscii",
@@ -125,10 +121,6 @@ var genericMap = map[string]interface{}{
 	"trimPrefix":   func(a, b string) string { return strings.TrimPrefix(b, a) },
 	"nospace":      util.DeleteWhiteSpace,
 	"initials":     initials,
-	"cryptoRandAlphaNum": cryptoRandAlphaNumeric,
-	"cryptoRandAlpha":    cryptoRandAlpha,
-	"cryptoRandAscii":    cryptoRandAscii,
-	"cryptoRandNumeric":  cryptoRandNumeric,
 	"randAlphaNum": randAlphaNumeric,
 	"randAlpha":    randAlpha,
 	"randAscii":    randAscii,

--- a/strings.go
+++ b/strings.go
@@ -55,44 +55,24 @@ func initials(s string) string {
 	return util.Initials(s)
 }
 
-func cryptoRandAlphaNumeric(count int) string {
+func randAlphaNumeric(count int) string {
+	// It is not possible, it appears, to actually generate an error here.
 	r, _ := util.CryptoRandomAlphaNumeric(count)
 	return r
 }
 
-func cryptoRandAlpha(count int) string {
+func randAlpha(count int) string {
 	r, _ := util.CryptoRandomAlphabetic(count)
 	return r
 }
 
-func cryptoRandAscii(count int) string {
+func randAscii(count int) string {
 	r, _ := util.CryptoRandomAscii(count)
 	return r
 }
 
-func cryptoRandNumeric(count int) string {
-	r, _ := util.CryptoRandomNumeric(count)
-	return r
-}
-
-func randAlphaNumeric(count int) string {
-	// It is not possible, it appears, to actually generate an error here.
-	r, _ := util.RandomAlphaNumeric(count)
-	return r
-}
-
-func randAlpha(count int) string {
-	r, _ := util.RandomAlphabetic(count)
-	return r
-}
-
-func randAscii(count int) string {
-	r, _ := util.RandomAscii(count)
-	return r
-}
-
 func randNumeric(count int) string {
-	r, _ := util.RandomNumeric(count)
+	r, _ := util.CryptoRandomNumeric(count)
 	return r
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -4,11 +4,9 @@ import (
 	"encoding/base32"
 	"encoding/base64"
 	"fmt"
-	"math/rand"
 	"testing"
 	"unicode/utf8"
 
-	"github.com/Masterminds/goutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -190,49 +188,30 @@ func TestGoutils(t *testing.T) {
 	}
 }
 
-func TestCryptoRandom(t *testing.T) {
-	// These tests have no predictable character sequence. No checks for exact string output are necessary.
-
-	// {{cryptoRandAlphaNum 5}} should yield five random characters
-	if x, _ := runRaw(`{{cryptoRandAlphaNum 5}}`, nil); utf8.RuneCountInString(x) != 5 {
-		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
-	}
-
-	// {{cryptoRandAlpha 5}} should yield five random characters
-	if x, _ := runRaw(`{{cryptoRandAlpha 5}}`, nil); utf8.RuneCountInString(x) != 5 {
-		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
-	}
-
-	// {{cryptoRandAscii 5}} should yield five random characters
-	if x, _ := runRaw(`{{cryptoRandAscii 5}}`, nil); utf8.RuneCountInString(x) != 5 {
-		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
-	}
-
-	// {{cryptoRandNumeric 5}} should yield five random characters
-	if x, _ := runRaw(`{{cryptoRandNumeric 5}}`, nil); utf8.RuneCountInString(x) != 5 {
-		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
-	}
-}
-
 func TestRandom(t *testing.T) {
-	// One of the things I love about Go:
-	goutils.RANDOM = rand.New(rand.NewSource(1))
+	// Randome strings are now using Masterminds/goutils's cryptographically secure random string functions
+	// by default. Consequently, these tests now have no predictable character sequence. No checks for exact
+	// string output are necessary.
 
-	// Because we're using a random number generator, we need these to go in
-	// a predictable sequence:
-	if err := runt(`{{randAlphaNum 5}}`, "9bzRv"); err != nil {
-		t.Errorf("Error on tpl: %s", err)
-	}
-	if err := runt(`{{randAlpha 5}}`, "VjwGe"); err != nil {
-		t.Errorf("Error on tpl: %s", err)
-	}
-	if err := runt(`{{randAscii 5}}`, "1KA5p"); err != nil {
-		t.Errorf("Error on tpl: %s", err)
-	}
-	if err := runt(`{{randNumeric 5}}`, "26018"); err != nil {
-		t.Errorf("Error on tpl: %s", err)
+	// {{randAlphaNum 5}} should yield five random characters
+	if x, _ := runRaw(`{{randAlphaNum 5}}`, nil); utf8.RuneCountInString(x) != 5 {
+		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
 	}
 
+	// {{randAlpha 5}} should yield five random characters
+	if x, _ := runRaw(`{{randAlpha 5}}`, nil); utf8.RuneCountInString(x) != 5 {
+		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
+	}
+
+	// {{randAscii 5}} should yield five random characters
+	if x, _ := runRaw(`{{randAscii 5}}`, nil); utf8.RuneCountInString(x) != 5 {
+		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
+	}
+
+	// {{randNumeric 5}} should yield five random characters
+	if x, _ := runRaw(`{{randNumeric 5}}`, nil); utf8.RuneCountInString(x) != 5 {
+		t.Errorf("String should be 5 characters; string was %v characters", utf8.RuneCountInString(x))
+	}
 }
 
 func TestCat(t *testing.T) {


### PR DESCRIPTION
As discussed in https://github.com/Masterminds/sprig/pull/135, this PR makes the random string generators in Sprig use the cryptographically secure generators (backed by `crypto/rand`) from `Masterminds/goutils` by default.

See the comment https://github.com/Masterminds/sprig/pull/135#issuecomment-451345233 through to the end for more context and performance testing metrics.

@technosophos 