### PR TITLE
kebabcase is lowercase

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -322,7 +322,7 @@ camelcase "http_server"
 
 This above will produce `HttpServer`.
 
-## kebabCase
+## kebabcase
 
 Convert string from camelCase to kebab-case.
 


### PR DESCRIPTION
kebabCase should be "kebabcase". See:

https://github.com/Masterminds/sprig/blob/2625cd487a689ca112e1301a58b89b347ba2c994/functions.go#L132