### PR TITLE
regexFindAll documentation missing last parameter

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -375,10 +375,11 @@ The above produces `true`
 
 ## regexFindAll
 
-Returns a slice of all matches of the regular expression in the input string
+Returns a slice of all matches of the regular expression in the input string.
+The last parameter n determines the number of substrings to return, where -1 means return all matches
 
 ```
-regexFindAll "[2,4,6,8]" "123456789 
+regexFindAll "[2,4,6,8]" "123456789" -1
 ```
 
 The above produces `[2 4 6 8]`


### PR DESCRIPTION
Last parameter of "regexFindAll" is not documented.
It maps to https://golang.org/pkg/regexp/#Regexp.FindAllString 
"These routines take an extra integer argument, n. If n >= 0, the function returns at most n matches/submatches; otherwise, it returns all of them. "