### PR TITLE
Default Functions missing ternary or etc

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ The Sprig library provides over 70 template functions for Go's template language
 - [Math Functions](math.md): `add`, `max`, `mul`, etc.
   - [Integer Slice Functions](integer_slice.md): `until`, `untilStep`
 - [Date Functions](date.md): `now`, `date`, etc.
-- [Defaults Functions](defaults.md): `default`, `empty`, `coalesce`, `toJson`, `toPrettyJson`
+- [Defaults Functions](defaults.md): `default`, `empty`, `coalesce`, `toJson`, `toPrettyJson`, `ternary`
 - [Encoding Functions](encoding.md): `b64enc`, `b64dec`, etc.
 - [Lists and List Functions](lists.md): `list`, `first`, `uniq`, etc.
 - [Dictionaries and Dict Functions](dicts.md): `dict`, `hasKey`, `pluck`, etc.


### PR DESCRIPTION
Index page convention seems to be: 
1. group functions by category
2. list all functions in a category
3. or list some functions in a category (likely the most used) and suggest with ", etc." there are more functions to discover by following the link

"Default Functions" breaks this assumption by presenting a list not followed by "etc." that is shorter than the one presented by defaults.md ("ternary" function is missing).

Here we can either add "ternary" to the list or append "etc." and maybe shorten the list of presented functions from 5 elements to 3.