### PR TITLE
Crypto and Security functions index missing etc

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,5 +19,5 @@ The Sprig library provides over 70 template functions for Go's template language
   - [OS Functions](os.md): `env`, `expandenv`
   - [Version Comparison Functions](semver.md): `semver`, `semverCompare`
   - [Reflection](reflection.md): `typeOf`, `kindIs`, `typeIsLike`, etc.
-  - [Cryptographic and Security Functions](crypto.md): `derivePassword`, `sha256sum`, `genPrivateKey`
+  - [Cryptographic and Security Functions](crypto.md): `derivePassword`, `sha256sum`, `genPrivateKey`, etc.
 


### PR DESCRIPTION
.etc missing next to "Cryptographic and Security Functions" in index page. There are more functions present in crypto.md than the ones listed by index.