### PR TITLE
Adding function to get unix epoch for a time

### DIFF
--- a/date.go
+++ b/date.go
@@ -1,6 +1,7 @@
 package sprig
 
 import (
+	"strconv"
 	"time"
 )
 
@@ -73,4 +74,8 @@ func dateAgo(date interface{}) string {
 func toDate(fmt, str string) time.Time {
 	t, _ := time.ParseInLocation(fmt, str, time.Local)
 	return t
+}
+
+func unixEpoch(date time.Time) string {
+	return strconv.FormatInt(date.Unix(), 10)
 }

--- a/date_test.go
+++ b/date_test.go
@@ -34,3 +34,15 @@ func TestToDate(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestUnixEpoch(t *testing.T) {
+	tm, err := time.Parse("02 Jan 06 15:04:05 MST", "13 Jun 19 20:39:39 GMT")
+	if err != nil {
+		t.Error(err)
+	}
+	tpl := `{{unixEpoch .Time}}`
+
+	if err = runtv(tpl, "1560458379", map[string]interface{}{"Time": tm}); err != nil {
+		t.Error(err)
+	}
+}

--- a/docs/date.md
+++ b/docs/date.md
@@ -47,6 +47,14 @@ Same as `date`, but with a timezone.
 date "2006-01-02" (now) "UTC"
 ```
 
+## unixEpoch
+
+Returns the seconds since the unix epoch for a `time.Time`.
+
+```
+now | unixEpoch
+```
+
 ## dateModify
 
 The `dateModify` takes a modification and a date and returns the timestamp.

--- a/functions.go
+++ b/functions.go
@@ -100,6 +100,7 @@ var genericMap = map[string]interface{}{
 	"dateModify":     dateModify,
 	"ago":            dateAgo,
 	"toDate":         toDate,
+	"unixEpoch":      unixEpoch,
 
 	// Strings
 	"abbrev":     abbrev,


### PR DESCRIPTION
It appears there is no format option for golang time to print out the seconds since the unix epoch. So, here is a template function to do that.