### PR TITLE
Feature/list concat

### DIFF
--- a/docs/lists.md
+++ b/docs/lists.md
@@ -48,7 +48,7 @@ The above would set `$new` to `[1 2 3 4 5 6]`. `$myList` would remain unaltered.
 
 ## prepend
 
-Push an alement onto the front of a list, creating a new list.
+Push an element onto the front of a list, creating a new list.
 
 ```
 prepend $myList 0

--- a/docs/lists.md
+++ b/docs/lists.md
@@ -56,6 +56,16 @@ prepend $myList 0
 
 The above would produce `[0 1 2 3 4 5]`. `$myList` would remain unaltered.
 
+## concat
+
+Concatenate arbitrary number of lists into one.
+
+```
+concat $myList ( list 6 7 ) ( list 8 )
+```
+
+The above would produce `[1 2 3 4 5 6 7 8]`. `$myList` would remain unaltered.
+
 ## reverse
 
 Produce a new list with the reversed elements of the given list.

--- a/functions.go
+++ b/functions.go
@@ -260,6 +260,7 @@ var genericMap = map[string]interface{}{
 	"without": without,
 	"has":     has,
 	"slice":   slice,
+	"concat":  concat,
 
 	// Crypto:
 	"genPrivateKey":     generatePrivateKey,

--- a/list.go
+++ b/list.go
@@ -292,3 +292,20 @@ func slice(list interface{}, indices ...interface{}) interface{} {
 		panic(fmt.Sprintf("list should be type of slice or array but %s", tp))
 	}
 }
+
+func concat(lists ...interface{}) interface{} {
+	var res []interface{}
+	for _, list := range lists {
+		tp := reflect.TypeOf(list).Kind()
+		switch tp {
+		case reflect.Slice, reflect.Array:
+			l2 := reflect.ValueOf(list)
+			for i := 0; i < l2.Len(); i++ {
+				res = append(res, l2.Index(i).Interface())
+			}
+		default:
+			panic(fmt.Sprintf("Cannot concat type %s as list", tp))
+		}
+	}
+	return res
+}

--- a/list_test.go
+++ b/list_test.go
@@ -169,3 +169,16 @@ func TestSlice(t *testing.T) {
 		assert.NoError(t, runt(tpl, expect))
 	}
 }
+
+func TestConcat(t *testing.T) {
+	tests := map[string]string{
+		`{{ concat (list 1 2 3) }}`:                                   "[1 2 3]",
+		`{{ concat (list 1 2 3) (list 4 5) }}`:                        "[1 2 3 4 5]",
+		`{{ concat (list 1 2 3) (list 4 5) (list) }}`:                 "[1 2 3 4 5]",
+		`{{ concat (list 1 2 3) (list 4 5) (list nil) }}`:             "[1 2 3 4 5 <nil>]",
+		`{{ concat (list 1 2 3) (list 4 5) (list ( list "foo" ) ) }}`: "[1 2 3 4 5 [6]]",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}

--- a/list_test.go
+++ b/list_test.go
@@ -176,7 +176,7 @@ func TestConcat(t *testing.T) {
 		`{{ concat (list 1 2 3) (list 4 5) }}`:                        "[1 2 3 4 5]",
 		`{{ concat (list 1 2 3) (list 4 5) (list) }}`:                 "[1 2 3 4 5]",
 		`{{ concat (list 1 2 3) (list 4 5) (list nil) }}`:             "[1 2 3 4 5 <nil>]",
-		`{{ concat (list 1 2 3) (list 4 5) (list ( list "foo" ) ) }}`: "[1 2 3 4 5 [6]]",
+		`{{ concat (list 1 2 3) (list 4 5) (list ( list "foo" ) ) }}`: "[1 2 3 4 5 [foo]]",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))


### PR DESCRIPTION
Added list concatenation function.

Motivation: in complex templates (helm, for instance), combining lists is a viable function (instead of copy-pasting template parts for different lists).