### PR TITLE
add deepEqual function

### DIFF
--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -36,3 +36,15 @@ Types are slightly harder to work with, so there are three different functions:
 
 **Note:** None of these can test whether or not something implements a given
 interface, since doing so would require compiling the interface in ahead of time.
+
+## deepEqual
+
+`deepEqual` returns true if two values are ["deeply equal"](https://golang.org/pkg/reflect/#DeepEqual)
+
+Works for non-primitive types as well (compared to the built-in `eq`).
+
+```
+deepEqual (list 1 2 3) (list 1 2 3)
+```
+
+The above will return `true`

--- a/functions.go
+++ b/functions.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"os"
 	"path"
+	"reflect"
 	"strconv"
 	"strings"
 	ttemplate "text/template"
@@ -134,20 +135,20 @@ var genericMap = map[string]interface{}{
 	"wrap":         func(l int, s string) string { return util.Wrap(s, l) },
 	"wrapWith":     func(l int, sep, str string) string { return util.WrapCustom(str, l, sep, true) },
 	// Switch order so that "foobar" | contains "foo"
-	"contains":  func(substr string, str string) bool { return strings.Contains(str, substr) },
-	"hasPrefix": func(substr string, str string) bool { return strings.HasPrefix(str, substr) },
-	"hasSuffix": func(substr string, str string) bool { return strings.HasSuffix(str, substr) },
-	"quote":     quote,
-	"squote":    squote,
-	"cat":       cat,
-	"indent":    indent,
-	"nindent":   nindent,
-	"replace":   replace,
-	"plural":    plural,
-	"sha1sum":   sha1sum,
-	"sha256sum": sha256sum,
+	"contains":   func(substr string, str string) bool { return strings.Contains(str, substr) },
+	"hasPrefix":  func(substr string, str string) bool { return strings.HasPrefix(str, substr) },
+	"hasSuffix":  func(substr string, str string) bool { return strings.HasSuffix(str, substr) },
+	"quote":      quote,
+	"squote":     squote,
+	"cat":        cat,
+	"indent":     indent,
+	"nindent":    nindent,
+	"replace":    replace,
+	"plural":     plural,
+	"sha1sum":    sha1sum,
+	"sha256sum":  sha256sum,
 	"adler32sum": adler32sum,
-	"toString":  strval,
+	"toString":   strval,
 
 	// Wrap Atoi to stop errors.
 	"atoi":    func(a string) int { i, _ := strconv.Atoi(a); return i },
@@ -216,6 +217,7 @@ var genericMap = map[string]interface{}{
 	"typeIsLike": typeIsLike,
 	"kindOf":     kindOf,
 	"kindIs":     kindIs,
+	"deepEqual":  reflect.DeepEqual,
 
 	// OS:
 	"env":       func(s string) string { return os.Getenv(s) },
@@ -235,19 +237,19 @@ var genericMap = map[string]interface{}{
 	"b32dec": base32decode,
 
 	// Data Structures:
-	"tuple":  list, // FIXME: with the addition of append/prepend these are no longer immutable.
-	"list":   list,
-	"dict":   dict,
-	"set":    set,
-	"unset":  unset,
-	"hasKey": hasKey,
-	"pluck":  pluck,
-	"keys":   keys,
-	"pick":   pick,
-	"omit":   omit,
-	"merge":  merge,
+	"tuple":          list, // FIXME: with the addition of append/prepend these are no longer immutable.
+	"list":           list,
+	"dict":           dict,
+	"set":            set,
+	"unset":          unset,
+	"hasKey":         hasKey,
+	"pluck":          pluck,
+	"keys":           keys,
+	"pick":           pick,
+	"omit":           omit,
+	"merge":          merge,
 	"mergeOverwrite": mergeOverwrite,
-	"values": values,
+	"values":         values,
 
 	"append": push, "push": push,
 	"prepend": prepend,


### PR DESCRIPTION
I found myself in a situation where I really missed comparing two lists or two maps (mostly in Helm charts). I think `deepEqual` would help there a lot in those situations.