### PR TITLE
Fix compilation of semver function

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,6 @@ import:
   subpackages:
   - scrypt
 - package: github.com/Masterminds/semver
-  version: ^v1.2.2
 - package: github.com/stretchr/testify
   version: ^v1.2.2
 - package: github.com/imdario/mergo

--- a/semver.go
+++ b/semver.go
@@ -19,5 +19,6 @@ func semverCompare(constraint, version string) (bool, error) {
 }
 
 func semver(version string) (*sv2.Version, error) {
-	return sv2.NewVersion(version)
+	v, err := sv2.NewVersion(version)
+	return &v, err
 }


### PR DESCRIPTION
The latest Masterminds/semver library returns a basic struct type, not a
pointer.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>