### PR TITLE
Add `get` support to dicts

### DIFF
--- a/dict.go
+++ b/dict.go
@@ -5,6 +5,13 @@ import (
 	"github.com/mitchellh/copystructure"
 )
 
+func get(d map[string]interface{}, key string) interface{} {
+	if val, ok := d[key]; ok {
+		return val
+	}
+	return ""
+}
+
 func set(d map[string]interface{}, key string, value interface{}) map[string]interface{} {
 	d[key] = value
 	return d

--- a/dict_test.go
+++ b/dict_test.go
@@ -111,6 +111,19 @@ func TestOmit(t *testing.T) {
 	}
 }
 
+func TestGet(t *testing.T) {
+	tests := map[string]string{
+		`{{- $d := dict "one" 1 }}{{ get $d "one"  -}}`:          "1",
+		`{{- $d := dict "one" 1 "two" "2" }}{{ get $d "two" -}}`: "2",
+		`{{- $d := dict }}{{ get $d "two" -}}`:                   "",
+	}
+	for tpl, expect := range tests {
+		if err := runt(tpl, expect); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
 func TestSet(t *testing.T) {
 	tpl := `{{- $d := dict "one" 1 "two" 222222 -}}
 	{{- $_ := set $d "two" 2 -}}

--- a/dict_test.go
+++ b/dict_test.go
@@ -113,7 +113,7 @@ func TestOmit(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	tests := map[string]string{
-		`{{- $d := dict "one" 1 }}{{ get $d "one"  -}}`:          "1",
+		`{{- $d := dict "one" 1 }}{{ get $d "one" -}}`:           "1",
 		`{{- $d := dict "one" 1 "two" "2" }}{{ get $d "two" -}}`: "2",
 		`{{- $d := dict }}{{ get $d "two" -}}`:                   "",
 	}

--- a/docs/dicts.md
+++ b/docs/dicts.md
@@ -20,6 +20,19 @@ The following creates a dictionary with three items:
 $myDict := dict "name1" "value1" "name2" "value2" "name3" "value 3"
 ```
 
+## get
+
+Given a map and a key, get the value from the map.
+
+```
+get $myDict "key1"
+```
+
+The above returns `"value1"`
+
+Note that if the key is not found, this operation will simply return `""`. No error
+will be generated.
+
 ## set
 
 Use `set` to add a new key/value pair to a dictionary.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ The Sprig library provides over 70 template functions for Go's template language
 - [Defaults Functions](defaults.md): `default`, `empty`, `coalesce`, `toJson`, `toPrettyJson`, `ternary`
 - [Encoding Functions](encoding.md): `b64enc`, `b64dec`, etc.
 - [Lists and List Functions](lists.md): `list`, `first`, `uniq`, etc.
-- [Dictionaries and Dict Functions](dicts.md): `dict`, `hasKey`, `pluck`, `deepCopy`, etc.
+- [Dictionaries and Dict Functions](dicts.md): `get`, `set`, `dict`, `hasKey`, `pluck`, `deepCopy`, etc.
 - [Type Conversion Functions](conversion.md): `atoi`, `int64`, `toString`, etc.
 - [File Path Functions](paths.md): `base`, `dir`, `ext`, `clean`, `isAbs`
 - [Flow Control Functions](flow_control.md): `fail`

--- a/functions.go
+++ b/functions.go
@@ -256,6 +256,7 @@ var genericMap = map[string]interface{}{
 	"tuple":              list, // FIXME: with the addition of append/prepend these are no longer immutable.
 	"list":               list,
 	"dict":               dict,
+	"get":                get,
 	"set":                set,
 	"unset":              unset,
 	"hasKey":             hasKey,


### PR DESCRIPTION
Closes: https://github.com/Masterminds/sprig/issues/151

```
get $myDict "key1"
```

The above returns `"value1"`