### PR TITLE
Avoid unnecessary conversion

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -97,7 +97,7 @@ func toRawJson(v interface{}) string {
 	if err != nil {
 		panic(err)
 	}
-	return string(output)
+	return output
 }
 
 // mustToRawJson encodes an item into a JSON string with no escaping of HTML characters.


### PR DESCRIPTION
No need to convert output to a string, it already is.