### PR TITLE
change: toRawJson: matching toJson behaviour while dealing with Marshaling errors

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -93,10 +93,7 @@ func mustToPrettyJson(v interface{}) (string, error) {
 
 // toRawJson encodes an item into a JSON string with no escaping of HTML characters.
 func toRawJson(v interface{}) string {
-	output, err := mustToRawJson(v)
-	if err != nil {
-		panic(err)
-	}
+	output, _ := mustToRawJson(v)
 	return string(output)
 }
 

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -81,7 +81,8 @@ The above returns indented JSON string representation of `.Item`.
 
 ## toRawJson, mustToRawJson
 
-The `toRawJson` function encodes an item into JSON string with HTML characters unescaped.
+The `toRawJson` function encodes an item into JSON string with HTML characters unescaped. If the item cannot be converted to JSON the function will return an empty string.
+`mustToRawJson` will return an error in case the item cannot be encoded in JSON.
 
 ```
 toRawJson .Item


### PR DESCRIPTION
Hello,
While looking at the implementation of `toRawJson`, I found out that the error handling was different than `toJson`, and I guess we should use a silent error as `toJson` instead of a `panic`, as if user would like to be notified of a problem while marshalling, he would have used `mustToRawJson`.

Thanks for your time,
Romain