### PR TITLE
Updating license for GitHub display

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,4 @@
-Sprig
-Copyright (C) 2013 Masterminds
+Copyright (C) 2013-2020 Masterminds
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The license file was not displaying as MIT on the homepage on GitHub.
Updating the format so it should display as MIT and updating the
years range.