### PR TITLE
Add network.md to index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,4 +20,5 @@ The Sprig library provides over 70 template functions for Go's template language
   - [Version Comparison Functions](semver.md): `semver`, `semverCompare`
   - [Reflection](reflection.md): `typeOf`, `kindIs`, `typeIsLike`, etc.
   - [Cryptographic and Security Functions](crypto.md): `derivePassword`, `sha256sum`, `genPrivateKey`, etc.
+  - [Network](network.md): `getHostByName`
 


### PR DESCRIPTION
The network.md documentation was added in https://github.com/Masterminds/sprig/commit/ac14fb280b0322c1d3494610095ba68698f32bae but was never added to index.md.
