### PR TITLE
Add a bcrypt function

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"golang.org/x/crypto/bcrypt"
+	bcrypt_lib "golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/scrypt"
 )
 
@@ -49,15 +49,20 @@ func adler32sum(input string) string {
 	return fmt.Sprintf("%d", hash)
 }
 
+func bcrypt(input string) string {
+	hash, err := bcrypt_lib.GenerateFromPassword([]byte(input), bcrypt_lib.DefaultCost)
+	if err != nil {
+		return fmt.Sprintf("failed to encrypt string with bcrypt: %s", err)
+	}
+
+	return string(hash)
+}
+
 func htpasswd(username string, password string) string {
 	if strings.Contains(username, ":") {
 		return fmt.Sprintf("invalid username: %s", username)
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	if err != nil {
-		return fmt.Sprintf("failed to create htpasswd: %s", err)
-	}
-	return fmt.Sprintf("%s:%s", username, hash)
+	return fmt.Sprintf("%s:%s", username, bcrypt(password))
 }
 
 // uuidv4 provides a safe and secure UUID v4 implementation

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/bcrypt"
+	bcrypt_lib "golang.org/x/crypto/bcrypt"
 )
 
 const (
@@ -37,6 +37,16 @@ func TestAdler32Sum(t *testing.T) {
 	}
 }
 
+func TestBcrypt(t *testing.T) {
+	out, err := runRaw(`{{"abc" | bcrypt}}`, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if bcrypt_lib.CompareHashAndPassword([]byte(out), []byte("abc")) != nil {
+		t.Error("Generated hash is not the equivalent for password:", "abc")
+	}
+}
+
 type HtpasswdCred struct {
 	Username string
 	Password string
@@ -59,7 +69,7 @@ func TestHtpasswd(t *testing.T) {
 		if 0 != strings.Compare(credential.Username, result[0]) && credential.Valid {
 			t.Error("Generated username did not match for:", credential.Username)
 		}
-		if bcrypt.CompareHashAndPassword([]byte(result[1]), []byte(credential.Password)) != nil && credential.Valid {
+		if bcrypt_lib.CompareHashAndPassword([]byte(result[1]), []byte(credential.Password)) != nil && credential.Valid {
 			t.Error("Generated hash is not the equivalent for password:", credential.Password)
 		}
 	}

--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -28,6 +28,13 @@ The `adler32sum` function receives a string, and computes its Adler-32 checksum.
 ```
 adler32sum "Hello world!"
 ```
+## bcrypt
+
+The `bcrypt` function receives a string, and generates its `bcrypt` hash.
+
+```
+bcrypt "myPassword"
+```
 
 ## htpasswd
 

--- a/functions.go
+++ b/functions.go
@@ -299,6 +299,7 @@ var genericMap = map[string]interface{}{
 	"concat":      concat,
 
 	// Crypto:
+	"bcrypt":            bcrypt,
 	"htpasswd":          htpasswd,
 	"genPrivateKey":     generatePrivateKey,
 	"derivePassword":    derivePassword,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to sprig.

Sprig is a maintained project. Triaging and responding to pull requests happens several times per year rather than daily or weekly.
-->

Continues work at #225 by adding a `bcrypt` function. `htpasswd` has been modified to use the `bcrypt` function.

I could've gotten away with using the `htpasswd` function in my app and setting `username` to empty string but then I'd also have to trim off the leading `:`. This seems cleaner for everyone.

cc @rustycl0ck  