### PR TITLE
Add support for regex.QuoteMeta string conversion

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -446,6 +446,17 @@ The above produces `[pi a]`
 `regexSplit` panics if there is a problem and `mustRegexSplit` returns an error to the
 template engine if there is a problem.
 
+## regexQuoteMeta
+
+Returns a string that escapes all regular expression metacharacters inside the argument text;
+the returned string is a regular expression matching the literal text.
+
+```
+regexQuoteMeta "1.2.3"
+```
+
+The above produces `1\.2\.3`
+
 ## See Also...
 
 The [Conversion Functions](conversion.html) contain functions for converting

--- a/functions.go
+++ b/functions.go
@@ -332,6 +332,7 @@ var genericMap = map[string]interface{}{
 	"mustRegexReplaceAllLiteral": mustRegexReplaceAllLiteral,
 	"regexSplit":                 regexSplit,
 	"mustRegexSplit":             mustRegexSplit,
+	"regexQuoteMeta":             regexQuoteMeta,
 
 	// URLs:
 	"urlParse": urlParse,

--- a/functions_test.go
+++ b/functions_test.go
@@ -82,6 +82,11 @@ func TestShuffle(t *testing.T) {
 	assert.NoError(t, runt(`{{ shuffle "Hello World" }}`, "rldo HWlloe"))
 }
 
+func TestRegex(t *testing.T) {
+	assert.NoError(t, runt(`{{ regexQuoteMeta "1.2.3" }}`, "1\\.2\\.3"))
+	assert.NoError(t, runt(`{{ regexQuoteMeta "pretzel" }}`, "pretzel"))
+}
+
 // runt runs a template and checks that the output exactly matches the expected string.
 func runt(tpl, expect string) error {
 	return runtv(tpl, expect, map[string]string{})

--- a/regex.go
+++ b/regex.go
@@ -77,3 +77,7 @@ func mustRegexSplit(regex string, s string, n int) ([]string, error) {
 	}
 	return r.Split(s, n), nil
 }
+
+func regexQuoteMeta(s string) string {
+	return regexp.QuoteMeta(s)
+}

--- a/regex_test.go
+++ b/regex_test.go
@@ -196,3 +196,8 @@ func TestMustRegexSplit(t *testing.T) {
 		assert.Equal(t, c.expected, len(res), "case %#v", c.args)
 	}
 }
+
+func TestRegexQuoteMeta(t *testing.T) {
+	assert.Equal(t, "1\\.2\\.3", regexQuoteMeta("1.2.3"))
+	assert.Equal(t, "pretzel", regexQuoteMeta("pretzel"))
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to sprig.

Sprig is a maintained project. Triaging and responding to pull requests happens several times per year rather than daily or weekly.
-->

I'd like to be able to get a regex to match to a particular string in the file generated from a go template. This would enable that easily, and uses the existing golang regex package. This PR includes an addition to the docs.

Let me know if I need to make any edits or changes. 

Thank you!