### PR TITLE
Fix 'duration' to accept 'int' type

### DIFF
--- a/date.go
+++ b/date.go
@@ -90,6 +90,8 @@ func duration(sec interface{}) string {
 		n, _ = strconv.ParseInt(value, 10, 64)
 	case int64:
 		n = value
+	case int:
+		n = int64(value)
 	}
 	return (time.Duration(n) * time.Second).String()
 }

--- a/date_test.go
+++ b/date_test.go
@@ -1,6 +1,7 @@
 package sprig
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -95,6 +96,18 @@ func TestDateInZone(t *testing.T) {
 func TestDuration(t *testing.T) {
 	tpl := "{{ duration .Secs }}"
 	if err := runtv(tpl, "1m1s", map[string]interface{}{"Secs": "61"}); err != nil {
+		t.Error(err)
+	}
+	// check int
+	if err := runtv(tpl, "1m1s", map[string]interface{}{"Secs": 61}); err != nil {
+		t.Error(err)
+	}
+	// check int32
+	if err := runtv(tpl, "596523h14m7s", map[string]interface{}{"Secs": math.MaxInt32}); err != nil {
+		t.Error(err)
+	}
+	// check uint32
+	if err := runtv(tpl, "1193046h28m15s", map[string]interface{}{"Secs": math.MaxUint32}); err != nil {
 		t.Error(err)
 	}
 	if err := runtv(tpl, "1h0m0s", map[string]interface{}{"Secs": "3600"}); err != nil {


### PR DESCRIPTION
closes #269 

However, I could not verify for ` math.MaxInt64` as it wraps around and gives some negative duration on my system for that value.

<!--
Thank you for submitting a pull request to sprig.

Sprig is a maintained project. Triaging and responding to pull requests happens several times per year rather than daily or weekly.
-->
