### PR TITLE
Add getHostByName error handling

### DIFF
--- a/network.go
+++ b/network.go
@@ -6,7 +6,10 @@ import (
 )
 
 func getHostByName(name string) string {
-	addrs, _ := net.LookupHost(name)
-	//TODO: add error handing when release v3 comes out
+	addrs, err := net.LookupHost(name)
+	if err != nil {
+		return ""
+	}
+
 	return addrs[rand.Intn(len(addrs))]
 }

--- a/network_test.go
+++ b/network_test.go
@@ -15,4 +15,10 @@ func TestGetHostByName(t *testing.T) {
 	ip := net.ParseIP(resolvedIP)
 	assert.NotNil(t, ip)
 	assert.NotEmpty(t, ip)
+
+	tpl = `{{"nope.local" | getHostByName}}`
+
+	resolvedIP, _ = runRaw(tpl, nil)
+
+	assert.Empty(t, resolvedIP)
 }


### PR DESCRIPTION
If the host is not found in `getHostByName`  it returns an empty string.

Before it was panicking because n <= 0 in rand.Intn:
```
error calling getHostByName: invalid argument to Intn
```