### PR TITLE
docs: fix typo

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -22,7 +22,7 @@ import (
 //
 // Use this to pass the functions into the template engine:
 //
-// 	tpl := template.New("foo").Funcs(sprig.FuncMap()))
+// 	tpl := template.New("foo").Funcs(sprig.FuncMap())
 //
 func FuncMap() template.FuncMap {
 	return HtmlFuncMap()


### PR DESCRIPTION
Fix typo in docs