### PR TITLE
Version of pluck that takes a list of maps rather than varargs

### DIFF
--- a/dict.go
+++ b/dict.go
@@ -37,6 +37,18 @@ func pluck(key string, d ...map[string]interface{}) []interface{} {
 	return res
 }
 
+func pluckAll(key string, d []interface{}) []interface{} {
+	res := []interface{}{}
+	for _, entry := range d {
+		if e, ok := entry.(map[string]interface{}); ok {
+			if val, ok := e[key]; ok {
+				res = append(res, val)
+			}
+		}
+	}
+	return res
+}
+
 func keys(dicts ...map[string]interface{}) []string {
 	k := []string{}
 	for _, dict := range dicts {

--- a/dict_test.go
+++ b/dict_test.go
@@ -69,6 +69,21 @@ func TestPluck(t *testing.T) {
 	}
 }
 
+func TestPluckAll(t *testing.T) {
+	tpl := `
+	{{- $d := dict "one" 1 "two" 222222 -}}
+	{{- $d2 := dict "one" 1 "two" 33333 -}}
+	{{- $d3 := dict "one" 1 -}}
+	{{- $d4 := dict "one" 1 "two" 4444 -}}
+	{{- pluckAll "two" (list $d $d2 $d3 $d4) -}}
+	`
+
+	expect := "[222222 33333 4444]"
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestKeys(t *testing.T) {
 	tests := map[string]string{
 		`{{ dict "foo" 1 "bar" 2 | keys | sortAlpha }}`: "[bar foo]",

--- a/docs/dicts.md
+++ b/docs/dicts.md
@@ -88,6 +88,26 @@ inserted.
 A common idiom in Sprig templates is to uses `pluck... | first` to get the first
 matching key out of a collection of dictionaries.
 
+## pluckAll
+
+The `pluckAll` function is exactly the same as `pluck`, but rather than the
+multiple maps being provided as separate parameters the second parameter is
+expected to be a _list_ of dicts.
+
+```
+pluckAll "name1" $listOfDicts
+```
+
+The above will return a `list` containing every found value (`[value1 otherValue1]`).
+
+If any item in the list is _not_ a dict, or is a dict but does not contain the
+requested key, then that item will not have a corresponding item in the result
+list (and the length of the returned list will be less than the length of the
+input list).
+
+If the key is _found_ but the value is an empty value, that value will be
+inserted.
+
 ## dig
 
 The `dig` function traverses a nested set of dicts, selecting keys from a list

--- a/functions.go
+++ b/functions.go
@@ -299,6 +299,7 @@ var genericMap = map[string]interface{}{
 	"unset":              unset,
 	"hasKey":             hasKey,
 	"pluck":              pluck,
+	"pluckAll":           pluckAll,
 	"keys":               keys,
 	"pick":               pick,
 	"omit":               omit,


### PR DESCRIPTION
This PR adds a function `pluckAll` which works the same as `pluck` but expects the dicts-to-pluck-from as a single list-valued parameter rather than a series of varargs parameters.  My particular use-case is a Helm chart with data such as this in its values file:

```yaml
items:
- name: foo
  colour: red
- name: bar
  colour: green
```

and a template that wants to extract a list containing the colour of each item.

Fixes #304