### PR TITLE
Keep compatibility of slice function

### DIFF
--- a/list.go
+++ b/list.go
@@ -422,7 +422,7 @@ func slice(list interface{}, indices ...interface{}) interface{} {
 func mustSlice(list interface{}, indices ...interface{}) (interface{}, error) {
 	tp := reflect.TypeOf(list).Kind()
 	switch tp {
-	case reflect.Slice, reflect.Array:
+	case reflect.Slice, reflect.Array, reflect.String:
 		l2 := reflect.ValueOf(list)
 
 		l := l2.Len()
@@ -442,7 +442,7 @@ func mustSlice(list interface{}, indices ...interface{}) (interface{}, error) {
 
 		return l2.Slice(start, end).Interface(), nil
 	default:
-		return nil, fmt.Errorf("list should be type of slice or array but %s", tp)
+		return nil, fmt.Errorf("list should be type of string, slice or array but %s", tp)
 	}
 }
 

--- a/list_test.go
+++ b/list_test.go
@@ -331,6 +331,7 @@ func TestSlice(t *testing.T) {
 		`{{ slice (list 1 2 3) 1 3 }}`:                      "[2 3]",
 		`{{ slice (list 1 2 3) 1 }}`:                        "[2 3]",
 		`{{ slice (regexSplit "/" "foo/bar/baz" -1) 1 2 }}`: "[bar]",
+		`{{ slice "test" 1 3 }}`:                            "es",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))
@@ -344,6 +345,7 @@ func TestMustSlice(t *testing.T) {
 		`{{ mustSlice (list 1 2 3) 1 3 }}`:                      "[2 3]",
 		`{{ mustSlice (list 1 2 3) 1 }}`:                        "[2 3]",
 		`{{ mustSlice (regexSplit "/" "foo/bar/baz" -1) 1 2 }}`: "[bar]",
+		`{{ mustSlice "test" 1 3 }}`:                            "es",
 	}
 	for tpl, expect := range tests {
 		assert.NoError(t, runt(tpl, expect))


### PR DESCRIPTION
Predefined global functions also have `slice`.
https://golang.org/pkg/text/template/#hdr-Functions

It takes a string, slice, or array as the first argument.
>slice returns the result of slicing its first argument by the remaining arguments. Thus "slice x 1 2" is, in Go syntax, x[1:2], while "slice x" is x[:], "slice x 1" is x[1:], and "slice x 1 2 3" is x[1:2:3]. The first argument must be a string, slice, or array.

On the other hand, `slice` from Sprig doesn't take a string. It breaks compatibility.
https://play.golang.org/p/NPEYDpGjtx7

IMHO, the same template should work as is after introducing Sprig.
Thanks.