### PR TITLE
Change trunc to handle unicode (rune counting)

### DIFF
--- a/strings.go
+++ b/strings.go
@@ -187,11 +187,14 @@ func strval(v interface{}) string {
 }
 
 func trunc(c int, s string) string {
-	if c < 0 && len(s)+c > 0 {
-		return s[len(s)+c:]
+	rlen := len([]rune(s))
+	if c < 0 && rlen+c > 0 {
+		r := []rune(s)
+		return string(r[len(r)+c:])
 	}
-	if c >= 0 && len(s) > c {
-		return s[:c]
+	if c >= 0 && rlen > c {
+		r := []rune(s)
+		return string(r[:c])
 	}
 	return s
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -43,6 +43,25 @@ func TestTrunc(t *testing.T) {
 	}
 }
 
+func TestTruncWorksByRune(t *testing.T) {
+	tpl := `{{ "foo🧐ooo" | trunc 4 }}`
+	if err := runt(tpl, "foo🧐"); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{ "baaaa🧐ar" | trunc -3 }}`
+	if err := runt(tpl, "🧐ar"); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{ "baaaa🧐ar" | trunc -999 }}`
+	if err := runt(tpl, "baaaa🧐ar"); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{ "🧐baaaaaz" | trunc 0 }}`
+	if err := runt(tpl, ""); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestQuote(t *testing.T) {
 	tpl := `{{quote "a" "b" "c"}}`
 	if err := runt(tpl, `"a" "b" "c"`); err != nil {


### PR DESCRIPTION
Update the `trunc` func to count and truncate by rune instead of by byte. When truncating by byte, if a multi-byte unicode character is encountered, the character will be split and become invalid. Instead, trunc now looks at the rune count for truncation and a slice of runes for performing truncation.

After some searching it looks like `len([]rune(s))` is compiler optimized (https://go-review.googlesource.com/c/go/+/108985), so conversion of the string into a rune slice is not done until `trunc` knows truncation needs to be done.

A quick note that this does not fix `abbrev`, which performs byte counting like `trunc` did, but is in a separate package. If this PR is merged, or upon maintainer request in review, I can create a PR to the goutils package.

<!--
Thank you for submitting a pull request to sprig.

Sprig is a maintained project. Triaging and responding to pull requests happens several times per year rather than daily or weekly.
-->
