### PR TITLE
Use `v3` for the sample code in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To load the Sprig `FuncMap`:
 ```go
 
 import (
-  "github.com/Masterminds/sprig"
+  "github.com/Masterminds/sprig/v3"
   "html/template"
 )
 


### PR DESCRIPTION
Use of v3 in the sample code of the README, since v3 is the current major version.
