### PR TITLE
Add md5sum hash function

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -10,6 +10,7 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/hmac"
+	"crypto/md5"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -49,6 +50,11 @@ func sha1sum(input string) string {
 func adler32sum(input string) string {
 	hash := adler32.Checksum([]byte(input))
 	return fmt.Sprintf("%d", hash)
+}
+
+func md5sum(input string) string {
+	hash := md5.Sum([]byte(input))
+	return hex.EncodeToString(hash[:])
 }
 
 func bcrypt(input string) string {

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -46,6 +46,13 @@ func TestAdler32Sum(t *testing.T) {
 	}
 }
 
+func TestMd5Sum(t *testing.T) {
+	tpl := `{{"abc" | md5sum}}`
+	if err := runt(tpl, "900150983cd24fb0d6963f7d28e17f72"); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestBcrypt(t *testing.T) {
 	out, err := runRaw(`{{"abc" | bcrypt}}`, nil)
 	if err != nil {

--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -21,6 +21,17 @@ sha256sum "Hello world!"
 The above will compute the SHA 256 sum in an "ASCII armored" format that is
 safe to print.
 
+## md5sum
+
+The `md5sum` function receives a string, and computes it's MD5 digest.
+
+```
+md5sum "Hello world!"
+```
+
+The above will compute the MD5 sum in an "ASCII armored" format that is
+safe to print.
+
 ## adler32sum
 
 The `adler32sum` function receives a string, and computes its Adler-32 checksum.

--- a/functions.go
+++ b/functions.go
@@ -160,6 +160,7 @@ var genericMap = map[string]interface{}{
 	"sha1sum":    sha1sum,
 	"sha256sum":  sha256sum,
 	"adler32sum": adler32sum,
+	"md5sum":     md5sum,
 	"toString":   strval,
 
 	// Wrap Atoi to stop errors.


### PR DESCRIPTION
Hi sprig maintainer,

I think it would be handy to add md5sum to sprig. While md5sum is not the most up to date hash function, it is still in use in a number of software packages.

I'm eager to this in helm ultimately :)

Thanks
Olivier