### PR TITLE
docs: clarify semverCompare return value

### DIFF
--- a/docs/semver.md
+++ b/docs/semver.md
@@ -43,8 +43,8 @@ comparison operations.)
 
 ## semverCompare
 
-A more robust comparison function is provided as `semverCompare`. This version
-supports version ranges:
+A more robust comparison function is provided as `semverCompare`. It returns `true` if
+the constraint matches, or `false` if it does not match. This version supports version ranges:
 
 - `semverCompare "1.2.3" "1.2.3"` checks for an exact match
 - `semverCompare "^1.2.0" "1.2.3"` checks that the major and minor versions match, and that the patch 


### PR DESCRIPTION
The return value for `semverCompare` was not explicitly listed in the docs,
and I had to go check in the source code wether it's actually a boolean.

By listing the return type in the docs, we can make usage easier for other people.
