### PR TITLE
Fix some typo in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To load the Sprig `FuncMap`:
 ```go
 
 import (
-  "github.com/Masterminds/sprig"
+  "github.com/Masterminds/sprig/v3"
   "html/template"
 )
 

--- a/docs/mathf.md
+++ b/docs/mathf.md
@@ -33,7 +33,7 @@ Perform integer division with `divf`
 This is equivalent to `10 / 2 / 4` and will return `1.25`:
 
 ```
-subf 10 2 4
+divf 10 2 4
 ```
 
 ## mulf


### PR DESCRIPTION
Changes:
- [Readme.md] Update sprig version to v3 in ``Usage`` section
- [doc/mathf.md] Fix a typo
