### PR TITLE
New `getHostsByAddr` function for rDNS lookups

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,4 +21,4 @@ The Sprig library provides over 70 template functions for Go's template language
   - [Version Comparison Functions](semver.md): `semver`, `semverCompare`
   - [Reflection](reflection.md): `typeOf`, `kindIs`, `typeIsLike`, etc.
   - [Cryptographic and Security Functions](crypto.md): `derivePassword`, `sha256sum`, `genPrivateKey`, etc.
-  - [Network](network.md): `getHostByName`
+  - [Network](network.md): `getHostByName`, `getHostByAddr`

--- a/docs/network.md
+++ b/docs/network.md
@@ -4,8 +4,16 @@ Sprig network manipulation functions.
 
 ## getHostByName
 
-The `getHostByName` receives a domain name and returns the ip address.
+The `getHostByName` receives a domain name, performs a forward DNS lookup using the local resolver, and returns an ip address. If multiple addresses are returned, one is picked at random.
 
 ```
 getHostByName "www.google.com" would return the corresponding ip address of www.google.com
+```
+
+## getHostByAddr
+
+The `getHostByAddr` receives an IP address (as a string), performs a reverse DNS lookup using the local resolver, and returns a hostname. Note the response will be fully-qualified (i.e. includes a final `.`).
+
+```
+getHostByAddr "8.8.8.8" would return `dns.google.com.`.
 ```

--- a/functions.go
+++ b/functions.go
@@ -92,6 +92,7 @@ var nonhermeticFunctions = []string{
 
 	// Network
 	"getHostByName",
+	"getHostByAddr",
 }
 
 var genericMap = map[string]interface{}{
@@ -269,6 +270,7 @@ var genericMap = map[string]interface{}{
 
 	// Network:
 	"getHostByName": getHostByName,
+	"getHostByAddr": getHostByAddr,
 
 	// Paths:
 	"base":  path.Base,
@@ -336,20 +338,20 @@ var genericMap = map[string]interface{}{
 	"mustChunk":   mustChunk,
 
 	// Crypto:
-	"bcrypt":            bcrypt,
-	"htpasswd":          htpasswd,
-	"genPrivateKey":     generatePrivateKey,
-	"derivePassword":    derivePassword,
-	"buildCustomCert":   buildCustomCertificate,
-	"genCA":             generateCertificateAuthority,
-	"genCAWithKey":      generateCertificateAuthorityWithPEMKey,
-	"genSelfSignedCert": generateSelfSignedCertificate,
+	"bcrypt":                   bcrypt,
+	"htpasswd":                 htpasswd,
+	"genPrivateKey":            generatePrivateKey,
+	"derivePassword":           derivePassword,
+	"buildCustomCert":          buildCustomCertificate,
+	"genCA":                    generateCertificateAuthority,
+	"genCAWithKey":             generateCertificateAuthorityWithPEMKey,
+	"genSelfSignedCert":        generateSelfSignedCertificate,
 	"genSelfSignedCertWithKey": generateSelfSignedCertificateWithPEMKey,
-	"genSignedCert":     generateSignedCertificate,
-	"genSignedCertWithKey": generateSignedCertificateWithPEMKey,
-	"encryptAES":        encryptAES,
-	"decryptAES":        decryptAES,
-	"randBytes":         randBytes,
+	"genSignedCert":            generateSignedCertificate,
+	"genSignedCertWithKey":     generateSignedCertificateWithPEMKey,
+	"encryptAES":               encryptAES,
+	"decryptAES":               decryptAES,
+	"randBytes":                randBytes,
 
 	// UUIDs:
 	"uuidv4": uuidv4,

--- a/network.go
+++ b/network.go
@@ -10,3 +10,8 @@ func getHostByName(name string) string {
 	//TODO: add error handing when release v3 comes out
 	return addrs[rand.Intn(len(addrs))]
 }
+
+func getHostByAddr(addr string) string {
+	hosts, _ := net.LookupAddr(addr)
+	return hosts[0]
+}

--- a/network_test.go
+++ b/network_test.go
@@ -16,3 +16,11 @@ func TestGetHostByName(t *testing.T) {
 	assert.NotNil(t, ip)
 	assert.NotEmpty(t, ip)
 }
+
+func TestGetHostByAddr(t *testing.T) {
+	tpl := `{{"1.1.1.1" | getHostByAddr}}`
+
+	resolvedHost, _ := runRaw(tpl, nil)
+
+	assert.Equal(t, resolvedHost, "one.one.one.one.")
+}


### PR DESCRIPTION
A new `getHostsByAddr` function for doing reverse DNS lookups.

It replicates the existing forward DNS function `getHostByName`, but instead calls [net.LookupAddr](https://pkg.go.dev/net#LookupAddr).

The intended downstream use case is to allow [Grafana Loki](https://grafana.com/docs/loki/latest/clients/promtail/stages/template/#supported-functions) to resolve the IPs in log messages.

Included changes:
- Test for new function added.
- Docs for new function added & existing function expanded.
- Some auto-formatting in `functions.go` vscode did - no-op change.