### PR TITLE
Support subject alternative URIs when generating cryptographic certificates.

### DIFF
--- a/crypto_test.go
+++ b/crypto_test.go
@@ -303,6 +303,8 @@ func testGenSelfSignedCert(t *testing.T, keyAlgo *string) {
 		ip2  = "10.0.0.2"
 		dns1 = "bar.com"
 		dns2 = "bat.com"
+		uri1 = "https://www.example.com"
+		uri2 = "spiffe://example.com/workload"
 	)
 
 	var genSelfSignedCertExpr string
@@ -313,7 +315,7 @@ func testGenSelfSignedCert(t *testing.T, keyAlgo *string) {
 	}
 
 	tpl := fmt.Sprintf(
-		`{{- $cert := %s "%s" (list "%s" "%s") (list "%s" "%s") 365 }}
+		`{{- $cert := %s "%s" (list "%s" "%s") (list "%s" "%s") (list "%s" "%s") 365 }}
 {{ $cert.Cert }}`,
 		genSelfSignedCertExpr,
 		cn,
@@ -321,6 +323,8 @@ func testGenSelfSignedCert(t *testing.T, keyAlgo *string) {
 		ip2,
 		dns1,
 		dns2,
+		uri1,
+		uri2,
 	)
 
 	out, err := runRaw(tpl, nil)
@@ -342,6 +346,8 @@ func testGenSelfSignedCert(t *testing.T, keyAlgo *string) {
 	assert.Equal(t, ip2, cert.IPAddresses[1].String())
 	assert.Contains(t, cert.DNSNames, dns1)
 	assert.Contains(t, cert.DNSNames, dns2)
+	assert.Equal(t, uri1, cert.URIs[0].String())
+	assert.Equal(t, uri2, cert.URIs[1].String())
 	assert.False(t, cert.IsCA)
 }
 
@@ -366,6 +372,8 @@ func testGenSignedCert(t *testing.T, caKeyAlgo, certKeyAlgo *string) {
 		ip2  = "10.0.0.2"
 		dns1 = "bar.com"
 		dns2 = "bat.com"
+		uri1 = "https://www.example.com"
+		uri2 = "spiffe://example.com/workload"
 	)
 
 	var genCAExpr, genSignedCertExpr string
@@ -382,7 +390,7 @@ func testGenSignedCert(t *testing.T, caKeyAlgo, certKeyAlgo *string) {
 
 	tpl := fmt.Sprintf(
 		`{{- $ca := %s "foo" 365 }}
-{{- $cert := %s "%s" (list "%s" "%s") (list "%s" "%s") 365 $ca }}
+{{- $cert := %s "%s" (list "%s" "%s") (list "%s" "%s") (list "%s" "%s") 365 $ca }}
 {{ $cert.Cert }}
 `,
 		genCAExpr,
@@ -392,6 +400,8 @@ func testGenSignedCert(t *testing.T, caKeyAlgo, certKeyAlgo *string) {
 		ip2,
 		dns1,
 		dns2,
+		uri1,
+		uri2,
 	)
 	out, err := runRaw(tpl, nil)
 	if err != nil {
@@ -413,6 +423,8 @@ func testGenSignedCert(t *testing.T, caKeyAlgo, certKeyAlgo *string) {
 	assert.Equal(t, ip2, cert.IPAddresses[1].String())
 	assert.Contains(t, cert.DNSNames, dns1)
 	assert.Contains(t, cert.DNSNames, dns2)
+	assert.Equal(t, uri1, cert.URIs[0].String())
+	assert.Equal(t, uri2, cert.URIs[1].String())
 	assert.False(t, cert.IsCA)
 }
 


### PR DESCRIPTION
Resolves https://github.com/Masterminds/sprig/issues/340.

**Note**:  In its current form, this PR breaks current behavior by **requiring** a new argument for cryptographic functions.  How would Sprig maintainers prefer this be adjusted, if at all?


For convenience and reference, I'll include a snippet of https://github.com/Masterminds/sprig/issues/340 here:

---

Cryptographic Sprig functions (e.g., `genSelfSignedCert`, `genSelfSignedCertWithKey`, etc.) currently support clients passing in optional lists of IPs and alternate DNS names.

I propose that these same cryptographic functions may also support clients passing in subject alternative URIs.

The [crypto x509 package](https://pkg.go.dev/crypto/x509#Certificate)'s `Certificate` (which Sprig relies on) supports specifying URI subject alternative names, as written in [RFC5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6):

> The subject alternative name extension allows identities to be bound
  to the subject of the certificate.  These identities may be included
  in addition to or in place of the identity in the subject field of
  the certificate.  Defined options include an Internet electronic mail
  address, a DNS name, an IP address, and a **Uniform Resource Identifier
  (URI)**.

URIs **are essential** to [the SPIFFE standard](https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#2-spiffe-id), where:

> In an X.509 SVID, the corresponding SPIFFE ID is set as a URI type in the Subject Alternative Name extension