### PR TITLE
Show correct usage of duration

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -54,7 +54,7 @@ Formats a given amount of seconds as a `time.Duration`.
 This returns 1m35s
 
 ```
-duration 95
+duration "95"
 ```
 
 ## durationRound


### PR DESCRIPTION
`duration 95` returns 0, as it doesn't satisfy the types(string, int64) present in the switch statement. So the example should show `duration "95"`

<!--
Thank you for submitting a pull request to sprig.

Sprig is a maintained project. Triaging and responding to pull requests happens several times per year rather than daily or weekly.
-->
