### PR TITLE
docs: Add missing link to url functions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,3 +22,4 @@ The Sprig library provides over 70 template functions for Go's template language
   - [Reflection](reflection.md): `typeOf`, `kindIs`, `typeIsLike`, etc.
   - [Cryptographic and Security Functions](crypto.md): `derivePassword`, `sha256sum`, `genPrivateKey`, etc.
   - [Network](network.md): `getHostByName`
+  - [URL](url.md): `urlParse`, `urlJoin`


### PR DESCRIPTION
URL parsing seemed like something that would be in sprig, but I didn't find it in the docs. When looking for a discussion about it, it turns out the code and docs were already there since a long time ago, just the link was missing! This PR adds the missing link.