### PR TITLE
Template function genCA to generate 4096 bits RSA private key

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -314,7 +314,7 @@ func generateCertificateAuthority(
 	cn string,
 	daysValid int,
 ) (certificate, error) {
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
 		return certificate{}, fmt.Errorf("error generating rsa key: %s", err)
 	}


### PR DESCRIPTION
Hi,

nowadays 2048 bits for a CA key is considered insecure, even if it is used internally.

Therefore I propose to change the default to 4096 bits.
