### PR TITLE
chore: update derivePassword URL

### DIFF
--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -71,7 +71,7 @@ randBytes 24
 
 The `derivePassword` function can be used to derive a specific password based on
 some shared "master password" constraints. The algorithm for this is
-[well specified](https://masterpassword.app/masterpassword-algorithm.pdf).
+[well specified](https://spectre.app/spectre-algorithm.pdf).
 
 ```
 derivePassword 1 "long" "password" "user" "example.com"


### PR DESCRIPTION
Updates the derivePassword reference paper URL.

The original link, https://masterpassword.app/masterpassword-algorithm.pdf is a 404 at present. The company [re-branded](https://spectre.app/blog/2021-10-31-spectre-ios-launch/) and changed the algorithm description PDF's filename (though amusingly not any of the references to the old name in the PDF's contents).

As best I can tell, https://spectre.app/spectre-algorithm.pdf is the current home of the previous document.

https://spectre.app/blog/2018-01-06-algorithm/ appears to describe the same in HTML form. Dunno if that'd be preferable. Unfortunately I couldn't find something that looked like it'd be a long-lived simple description of the algorithm in RFC format or similar.
