### PR TITLE
add SHA support to htpasswd

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -66,11 +66,32 @@ func bcrypt(input string) string {
 	return string(hash)
 }
 
-func htpasswd(username string, password string) string {
+func hashSha(password string) string {
+	s := sha1.New()
+	s.Write([]byte(password))
+	passwordSum := []byte(s.Sum(nil))
+	return base64.StdEncoding.EncodeToString(passwordSum)
+}
+
+// HashAlgorithm enum for hashing algorithms
+type HashAlgorithm string
+
+const (
+	// HashBCrypt bcrypt - recommended
+	HashBCrypt = "bcrypt"
+	HashSHA    = "sha"
+)
+
+func htpasswd(username string, password string, hashAlgorithm HashAlgorithm) string {
 	if strings.Contains(username, ":") {
 		return fmt.Sprintf("invalid username: %s", username)
 	}
-	return fmt.Sprintf("%s:%s", username, bcrypt(password))
+	switch hashAlgorithm {
+	case HashSHA:
+		return fmt.Sprintf("%s:{SHA}%s", username, hashSha(password))
+	default:
+		return fmt.Sprintf("%s:%s", username, bcrypt(password))
+	}
 }
 
 func randBytes(count int) (string, error) {

--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -49,10 +49,10 @@ bcrypt "myPassword"
 
 ## htpasswd
 
-The `htpasswd` function takes a `username` and `password` and generates a `bcrypt` hash of the password. The result can be used for basic authentication on an [Apache HTTP Server](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html#basic).
+The `htpasswd` function takes a `username`, a `password`, and a `hashAlgorithm` and generates a `bcrypt` (recommended) or a base64 encoded and prefixed `sha` hash of the password. `hashAlgorithm` is optional and defaults to `bcrypt`. The result can be used for basic authentication on an [Apache HTTP Server](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html#basic).
 
 ```
-htpasswd "myUser" "myPassword"
+htpasswd "myUser" "myPassword" ["bcrypt"|"sha"]
 ```
 
 Note that it is insecure to store the password directly in the template.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to sprig.

Sprig is a maintained project. Triaging and responding to pull requests happens several times per year rather than daily or weekly.
-->
My use case is to address hashicorp vault > external-password > k8s password > envoy gateway > envoy
envoy only supports sha encoding, external-password uses sprig, sprig encodes to bcrypt

This PR will allow to simplify this chain and partially fix #32.

I've opened a counterpart issue in envoy repo to also add bcrypt decoding support https://github.com/envoyproxy/envoy/issues/36278

I hope this will be fixed both ways, allowing better security with a smooth transition from sha to bcrypt on existing apps