### PR TITLE
feat(crypto): add uuidv5

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -86,6 +86,17 @@ func uuidv4() string {
 	return uuid.New().String()
 }
 
+// uuidv5 provides a safe and secure UUID v5 implementation
+func uuidv5(namespace, name string) string {
+	// The namespace is always a UUID
+	ns, err := uuid.Parse(namespace)
+	if err != nil {
+		return fmt.Sprintf("namespace must be a valid UUID")
+	}
+
+	return uuid.NewSHA1(ns, []byte(name)).String()
+}
+
 var masterPasswordSeed = "com.lyndir.masterpassword"
 
 var passwordTypeTemplates = map[string][][]byte{

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -201,7 +201,7 @@ func TestRandBytes(t *testing.T) {
 	}
 }
 
-func TestUUIDGeneration(t *testing.T) {
+func TestUUIDv4Generation(t *testing.T) {
 	tpl := `{{uuidv4}}`
 	out, err := runRaw(tpl, nil)
 	if err != nil {
@@ -219,6 +219,32 @@ func TestUUIDGeneration(t *testing.T) {
 
 	if out == out2 {
 		t.Error("Expected subsequent UUID generations to be different")
+	}
+}
+
+func TestUUIDv5Generation(t *testing.T) {
+	tpl := `{{uuidv5 "2be4f575-0625-4376-bfca-fc237ac4fd8a" "Hello World"}}`
+	out, err := runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(out) != 36 {
+		t.Error("Expected UUID of length 36")
+	}
+
+	out2, err := runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if out != out2 {
+		t.Error("Expected subsequent UUID generations to be identical")
+	}
+
+	tpl = `{{uuidv5 "2be4f575-0625-4376-bfca-fc237ac4fd8a" "Hello World"}}`
+	if err := runt(tpl, "c493a152-08ba-5679-a958-de98ebcc8160"); err != nil {
+		t.Error(err)
 	}
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ The Sprig library provides over 70 template functions for Go's template language
 - [Path and Filepath Functions](paths.md): `base`, `dir`, `ext`, `clean`, `isAbs`, `osBase`, `osDir`, `osExt`, `osClean`, `osIsAbs`
 - [Flow Control Functions](flow_control.md): `fail`
 - Advanced Functions
-  - [UUID Functions](uuid.md): `uuidv4`
+  - [UUID Functions](uuid.md): `uuidv4`, `uuidv5`
   - [OS Functions](os.md): `env`, `expandenv`
   - [Version Comparison Functions](semver.md): `semver`, `semverCompare`
   - [Reflection](reflection.md): `typeOf`, `kindIs`, `typeIsLike`, etc.

--- a/docs/uuid.md
+++ b/docs/uuid.md
@@ -1,5 +1,7 @@
 # UUID Functions
 
+## UUID v4
+
 Sprig can generate UUID v4 universally unique IDs.
 
 ```
@@ -7,3 +9,14 @@ uuidv4
 ```
 
 The above returns a new UUID of the v4 (randomly generated) type.
+
+## UUID v5
+
+Sprig can generate UUID v5 which can output deterministic IDs for a given namespace and name.
+
+```
+uuidv5 "2be4f575-0625-4376-bfca-fc237ac4fd8a" "Hello World"
+```
+
+The above returns a new deterministic UUID that will always be the same as long as the parameters stay identical.
+The output here would be `c493a152-08ba-5679-a958-de98ebcc8160`

--- a/functions.go
+++ b/functions.go
@@ -356,6 +356,7 @@ var genericMap = map[string]interface{}{
 
 	// UUIDs:
 	"uuidv4": uuidv4,
+	"uuidv5": uuidv5,
 
 	// SemVer:
 	"semver":        semver,


### PR DESCRIPTION
This pull request adds a new UUID function: `uuidv5`

UUIDv5 is different from the already implemented UUIDv4 functions because it is pseudo-random and deterministic.
It takes into input a "namespace", which we could call a seed of some sort. It then takes a "name" and outputs a UUID.


This feature is extremely useful for tools like Helm which depend on Sprig because of the determinism.
There are usecases where Helm Charts need to generate random IDs, but `uuidv4` doesn't survive upgrades because they get regenerated.

Having one single manually generated source of randomness (the namespace) and then using it everywhere in templates by specifying different "names" makes the UUID generation random for each template but also deterministic (it will survive through upgrades).

Considering the amount of questions on stackoverflow considering idempotence for randomly generated values, I think this function would be pretty useful.

@mattfarina considering you're a Helm maintainer, do you have a particular opinion on this matter? 