### PR TITLE
add mustB64dec (and mustB32dec) which fails on bad b64 data instead o…

### DIFF
--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -4,3 +4,4 @@ Sprig has the following encoding and decoding functions:
 
 - `b64enc`/`b64dec`: Encode or decode with Base64
 - `b32enc`/`b32dec`: Encode or decode with Base32
+- `mustB32dec`/`mustB64dec`: will return an error in case data is not valid encoded data.

--- a/functions.go
+++ b/functions.go
@@ -288,10 +288,12 @@ var genericMap = map[string]interface{}{
 	"osIsAbs": filepath.IsAbs,
 
 	// Encoding:
-	"b64enc": base64encode,
-	"b64dec": base64decode,
-	"b32enc": base32encode,
-	"b32dec": base32decode,
+	"b64enc":     base64encode,
+	"b64dec":     base64decode,
+	"mustB64dec": mustBase64decode,
+	"b32enc":     base32encode,
+	"b32dec":     base32decode,
+	"mustB32dec": mustBase32decode,
 
 	// Data Structures:
 	"tuple":              list, // FIXME: with the addition of append/prepend these are no longer immutable.

--- a/strings.go
+++ b/strings.go
@@ -16,11 +16,19 @@ func base64encode(v string) string {
 }
 
 func base64decode(v string) string {
-	data, err := base64.StdEncoding.DecodeString(v)
+	data, err := mustBase64decode(v)
 	if err != nil {
 		return err.Error()
 	}
-	return string(data)
+	return data
+}
+
+func mustBase64decode(v string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(v)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func base32encode(v string) string {
@@ -28,11 +36,19 @@ func base32encode(v string) string {
 }
 
 func base32decode(v string) string {
-	data, err := base32.StdEncoding.DecodeString(v)
+	data, err := mustBase32decode(v)
 	if err != nil {
 		return err.Error()
 	}
-	return string(data)
+	return data
+}
+
+func mustBase32decode(v string) (string, error) {
+	data, err := base32.StdEncoding.DecodeString(v)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func abbrev(width int, s string) string {

--- a/strings_test.go
+++ b/strings_test.go
@@ -154,6 +154,7 @@ func TestSortAlpha(t *testing.T) {
 		assert.NoError(t, runt(tpl, expect))
 	}
 }
+
 func TestBase64EncodeDecode(t *testing.T) {
 	magicWord := "coffee"
 	expect := base64.StdEncoding.EncodeToString([]byte(magicWord))
@@ -171,6 +172,32 @@ func TestBase64EncodeDecode(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestBase64DecodeErr(t *testing.T) {
+	expect := "illegal base64 data at input byte 4"
+
+	tpl := `{{b64dec "coffee"}}`
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestMustBase64Decode(t *testing.T) {
+	expect := "coffee"
+	b64data := base64.StdEncoding.EncodeToString([]byte(expect))
+
+	tpl := fmt.Sprintf("{{mustB64dec %q}}", b64data)
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestMustBase64DecodeErr(t *testing.T) {
+	tpl := `{{mustB64dec "coffee"}}`
+	_, err := runRaw(tpl, nil)
+	assert.EqualError(t, err, `template: test:1:2: executing "test" at <mustB64dec "coffee">: error calling mustB64dec: illegal base64 data at input byte 4`)
+}
+
 func TestBase32EncodeDecode(t *testing.T) {
 	magicWord := "coffee"
 	expect := base32.StdEncoding.EncodeToString([]byte(magicWord))
@@ -187,6 +214,31 @@ func TestBase32EncodeDecode(t *testing.T) {
 	if err := runt(tpl, magicWord); err != nil {
 		t.Error(err)
 	}
+}
+
+func TestBase32DecodeErr(t *testing.T) {
+	expect := "illegal base32 data at input byte 0"
+
+	tpl := `{{b32dec "coffee"}}`
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestMustBase32Decode(t *testing.T) {
+	expect := "coffee"
+	b32data := base32.StdEncoding.EncodeToString([]byte(expect))
+
+	tpl := fmt.Sprintf("{{mustB32dec %q}}", b32data)
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestMustBase32DecodeErr(t *testing.T) {
+	tpl := `{{mustB32dec "coffee"}}`
+	_, err := runRaw(tpl, nil)
+	assert.EqualError(t, err, `template: test:1:2: executing "test" at <mustB32dec "coffee">: error calling mustB32dec: illegal base32 data at input byte 0`)
 }
 
 func TestGoutils(t *testing.T) {


### PR DESCRIPTION
…f decoding to "illegal base64 data at input byte ..."

Closes #417

<!--
Thank you for submitting a pull request to sprig.

Sprig is a maintained project. Triaging and responding to pull requests happens several times per year rather than daily or weekly.
-->
