### PR TITLE
Add support for time.Duration to durationRound and duration

### DIFF
--- a/date.go
+++ b/date.go
@@ -86,6 +86,8 @@ func duration(sec interface{}) string {
 	switch value := sec.(type) {
 	default:
 		n = 0
+	case time.Duration:
+		n = int64(value / time.Second)
 	case string:
 		n, _ = strconv.ParseInt(value, 10, 64)
 	case int64:
@@ -99,6 +101,8 @@ func durationRound(duration interface{}) string {
 	switch duration := duration.(type) {
 	default:
 		d = 0
+	case time.Duration:
+		d = duration
 	case string:
 		d, _ = time.ParseDuration(duration)
 	case int64:

--- a/date_test.go
+++ b/date_test.go
@@ -97,6 +97,9 @@ func TestDuration(t *testing.T) {
 	if err := runtv(tpl, "1m1s", map[string]interface{}{"Secs": "61"}); err != nil {
 		t.Error(err)
 	}
+	if err := runtv(tpl, "1m15s", map[string]interface{}{"Secs": time.Duration(time.Second * 75)}); err != nil {
+		t.Error(err)
+	}
 	if err := runtv(tpl, "1h0m0s", map[string]interface{}{"Secs": "3600"}); err != nil {
 		t.Error(err)
 	}
@@ -108,6 +111,9 @@ func TestDuration(t *testing.T) {
 
 func TestDurationRound(t *testing.T) {
 	tpl := "{{ durationRound .Time }}"
+	if err := runtv(tpl, "1m", map[string]interface{}{"Time": time.Duration(time.Second * 75)}); err != nil {
+		t.Error(err)
+	}
 	if err := runtv(tpl, "2h", map[string]interface{}{"Time": "2h5s"}); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
The durationRound function is helpful to pretty-print existing durations.
Adding the same support for duration just for completeness (it does have
the minimal side-effect of truncating to a whole second)
