### PR TITLE
durationRound: use '1m' instead of '60s' (same for 1h/60m)

### DIFF
--- a/date.go
+++ b/date.go
@@ -130,9 +130,9 @@ func durationRound(duration interface{}) string {
 		return strconv.FormatUint(u/day, 10) + "d"
 	case u > hour:
 		return strconv.FormatUint(u/hour, 10) + "h"
-	case u > minute:
+	case u >= minute:
 		return strconv.FormatUint(u/minute, 10) + "m"
-	case u > second:
+	case u >= second:
 		return strconv.FormatUint(u/second, 10) + "s"
 	}
 	return "0s"

--- a/date_test.go
+++ b/date_test.go
@@ -117,4 +117,7 @@ func TestDurationRound(t *testing.T) {
 	if err := runtv(tpl, "3mo", map[string]interface{}{"Time": "2400h5s"}); err != nil {
 		t.Error(err)
 	}
+	if err := runtv(tpl, "1m", map[string]interface{}{"Time": time.Duration(time.Second * 60)}); err != nil {
+		t.Error(err)
+	}
 }


### PR DESCRIPTION
I realize in most applications it's just for a moment, but ... "60s" looks goofy, in particular when the data is rounded to "1m" a second after.