### PR TITLE
Add md5sum function to crypto library and add example usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 /.glide
+.idea

--- a/crypto.go
+++ b/crypto.go
@@ -10,6 +10,7 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/hmac"
+	"crypto/md5"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -71,6 +72,11 @@ func hashSha(password string) string {
 	s.Write([]byte(password))
 	passwordSum := []byte(s.Sum(nil))
 	return base64.StdEncoding.EncodeToString(passwordSum)
+}
+
+func md5sum(input string) string {
+	hash := md5.Sum([]byte(input))
+	return hex.EncodeToString(hash[:])
 }
 
 // HashAlgorithm enum for hashing algorithms

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -47,6 +47,13 @@ func TestSha1Sum(t *testing.T) {
 	}
 }
 
+func TestMd5Sum(t *testing.T) {
+	tpl := `{{"abc" | md5sum}}`
+	if err := runt(tpl, "900150983cd24fb0d6963f7d28e17f72"); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestAdler32Sum(t *testing.T) {
 	tpl := `{{"abc" | adler32sum}}`
 	if err := runt(tpl, "38600999"); err != nil {

--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -267,3 +267,11 @@ algorithm and returns the decoded text.
 ```
 "30tEfhuJSVRhpG97XCuWgz2okj7L8vQ1s6V9zVUPeDQ=" | decryptAES "secretkey"
 ```
+
+## md5sum
+
+The `md5sum` function receives a string, and computes it's MD5 digest.
+
+```
+md5sum "Hello world!"
+```

--- a/functions.go
+++ b/functions.go
@@ -163,6 +163,7 @@ var genericMap = map[string]interface{}{
 	"sha256sum":  sha256sum,
 	"sha512sum":  sha512sum,
 	"adler32sum": adler32sum,
+	"md5sum":     md5sum,
 	"toString":   strval,
 
 	// Wrap Atoi to stop errors.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to sprig.

Sprig is a maintained project. Triaging and responding to pull requests happens several times per year rather than daily or weekly.
-->

Add an `md5sum` function to list of supported crypto functions.
Add `.idea` to gitignore, because I use JetBrains (can remove if not needed).