### PR TITLE
add hexdec encoding function

### DIFF
--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -4,3 +4,4 @@ Sprig has the following encoding and decoding functions:
 
 - `b64enc`/`b64dec`: Encode or decode with Base64
 - `b32enc`/`b32dec`: Encode or decode with Base32
+- `printf "%x"` / `hexdec`: Encode or decode as hexadecimal

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ The Sprig library provides over 70 template functions for Go's template language
 - [Float Math Functions](mathf.md): `addf`, `maxf`, `mulf`, etc.
 - [Date Functions](date.md): `now`, `date`, etc.
 - [Defaults Functions](defaults.md): `default`, `empty`, `coalesce`, `fromJson`, `toJson`, `toPrettyJson`, `toRawJson`, `ternary`
-- [Encoding Functions](encoding.md): `b64enc`, `b64dec`, etc.
+- [Encoding Functions](encoding.md): `b64enc`, `b64dec`, `b32enc`, `b32dec`, `hexdec`
 - [Lists and List Functions](lists.md): `list`, `first`, `uniq`, etc.
 - [Dictionaries and Dict Functions](dicts.md): `get`, `set`, `dict`, `hasKey`, `pluck`, `dig`, `deepCopy`, etc.
 - [Type Conversion Functions](conversion.md): `atoi`, `int64`, `toString`, etc.

--- a/functions.go
+++ b/functions.go
@@ -292,6 +292,7 @@ var genericMap = map[string]interface{}{
 	"b64dec": base64decode,
 	"b32enc": base32encode,
 	"b32dec": base32decode,
+	"hexdec": hexdecode,
 
 	// Data Structures:
 	"tuple":              list, // FIXME: with the addition of append/prepend these are no longer immutable.

--- a/strings.go
+++ b/strings.go
@@ -3,6 +3,7 @@ package sprig
 import (
 	"encoding/base32"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -29,6 +30,14 @@ func base32encode(v string) string {
 
 func base32decode(v string) string {
 	data, err := base32.StdEncoding.DecodeString(v)
+	if err != nil {
+		return err.Error()
+	}
+	return string(data)
+}
+
+func hexdecode(v string) string {
+	data, err := hex.DecodeString(v)
 	if err != nil {
 		return err.Error()
 	}

--- a/strings_test.go
+++ b/strings_test.go
@@ -171,6 +171,16 @@ func TestBase64EncodeDecode(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestHexEncodeDecode(t *testing.T) {
+	magicWord := "\x00coffee\xfb"
+
+	tpl := `{{printf "%x" "\x00coffee\xfb" | hexdec }}`
+	if err := runt(tpl, magicWord); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestBase32EncodeDecode(t *testing.T) {
 	magicWord := "coffee"
 	expect := base32.StdEncoding.EncodeToString([]byte(magicWord))


### PR DESCRIPTION
The hash functions return their result as hex encoded strings. For some integration tasks, we need the base64 encoded hashes.
Instead of duplicating all hash functions, I added a single `hexdec` function that can achieve the same result:

```
`{{"abc" | sha256sum | hexdec | b64enc}}`
```
