### PR TITLE
Add abs and absf functions

### DIFF
--- a/docs/math.md
+++ b/docs/math.md
@@ -34,6 +34,16 @@ Multiply with `mul`. Accepts two or more inputs.
 mul 1 2 3
 ```
 
+## abs
+
+Return the absolute value of an integer.
+
+This will return `3`:
+
+```
+abs -3
+```
+
 ## max
 
 Return the largest of a series of integers:

--- a/docs/mathf.md
+++ b/docs/mathf.md
@@ -65,3 +65,13 @@ This will return `1.5`:
 ```
 minf 1.5 2 3
 ```
+
+## absf
+
+Return the absolute value of a float.
+
+This will return `3.14`:
+
+```
+absf -3.14
+```

--- a/functions.go
+++ b/functions.go
@@ -229,6 +229,8 @@ var genericMap = map[string]interface{}{
 	"min":     min,
 	"maxf":    maxf,
 	"minf":    minf,
+	"abs":     abs,
+	"absf":    absf,
 	"ceil":    ceil,
 	"floor":   floor,
 	"round":   round,

--- a/numeric.go
+++ b/numeric.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/spf13/cast"
 	"github.com/shopspring/decimal"
+	"github.com/spf13/cast"
 )
 
 // toFloat64 converts 64-bit floats
@@ -62,6 +62,19 @@ func minf(a interface{}, i ...interface{}) float64 {
 		aa = math.Min(aa, bb)
 	}
 	return aa
+}
+
+func abs(a interface{}) int64 {
+	aa := toInt64(a)
+	if aa < 0 {
+		return -aa
+	}
+	return aa
+}
+
+func absf(a interface{}) float64 {
+	aa := toFloat64(a)
+	return math.Abs(aa)
 }
 
 func until(count int) []int {

--- a/numeric_test.go
+++ b/numeric_test.go
@@ -277,6 +277,20 @@ func TestSubf(t *testing.T) {
 	}
 }
 
+func TestAbs(t *testing.T) {
+	tpl := `{{ abs -3 }}`
+	if err := runt(tpl, `3`); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAbsf(t *testing.T) {
+	tpl := `{{ absf -3.4 }}`
+	if err := runt(tpl, `3.4`); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestCeil(t *testing.T) {
 	assert.Equal(t, 123.0, ceil(123))
 	assert.Equal(t, 123.0, ceil("123"))


### PR DESCRIPTION
1. add abs for integer math
2. add absf for floating-point math
3. document the new functions
4. test the new functionality

That was asked for before https://github.com/Masterminds/sprig/issues/303
 