### PR TITLE
Enable use of P-384 and P-521 for genPrivateKey

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -186,9 +186,13 @@ func generatePrivateKey(typ string) string {
 		}
 		err = dsa.GenerateKey(key, rand.Reader)
 		priv = key
-	case "ecdsa":
+	case "ecdsa", "ec_p256":
 		// again, good enough for government work
 		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case "ec_p384":
+		priv, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	case "ec_p521":
+		priv, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	case "ed25519":
 		_, priv, err = ed25519.GenerateKey(rand.Reader)
 	default:

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -161,6 +161,30 @@ func TestGenPrivateKey(t *testing.T) {
 	if !strings.Contains(out, "EC PRIVATE KEY") {
 		t.Error("Expected EC PRIVATE KEY")
 	}
+	tpl = `{{genPrivateKey "ec_p256"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "EC PRIVATE KEY") {
+		t.Error("Expected EC PRIVATE KEY")
+	}
+	tpl = `{{genPrivateKey "ec_p384"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "EC PRIVATE KEY") {
+		t.Error("Expected EC PRIVATE KEY")
+	}
+	tpl = `{{genPrivateKey "ec_p521"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "EC PRIVATE KEY") {
+		t.Error("Expected EC PRIVATE KEY")
+	}
 	tpl = `{{genPrivateKey "ed25519"}}`
 	out, err = runRaw(tpl, nil)
 	if err != nil {

--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -86,7 +86,9 @@ block.
 
 It takes one of the values for its first param:
 
-- `ecdsa`: Generate an elliptic curve DSA key (P256)
+- `ecdsa`, `ec_p256`: Generate an elliptic curve DSA key (P-256)
+- `ec_p384`: Generate an elliptic curve DSA key (P-384)
+- `ec_p521`: Generate an elliptic curve DSA key (P-521)
 - `dsa`: Generate a DSA key (L2048N256)
 - `rsa`: Generate an RSA 4096 key
 - `ed25519`: Generate an Ed25519 key


### PR DESCRIPTION
Enables `genPrivateKey` to use the elliptic curves P-384 and P-521 by adding support for the type arguments `ec_p384` and `ec_p521`. Introduces `ec_p256` as alias to the existing type argument `ecdsa`.

Includes unittests and documentation.